### PR TITLE
Avoid cyclic type reference

### DIFF
--- a/src/main/java/org/komamitsu/fluency/buffer/Buffer.java
+++ b/src/main/java/org/komamitsu/fluency/buffer/Buffer.java
@@ -11,16 +11,15 @@ import java.io.File;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
-import java.nio.channels.ReadableByteChannel;
 import java.nio.charset.Charset;
 import java.util.List;
 import java.util.Map;
 
-public abstract class Buffer<T extends Buffer.Config>
+public abstract class Buffer
 {
     private static final Logger LOG = LoggerFactory.getLogger(Buffer.class);
     protected static final Charset CHARSET = Charset.forName("ASCII");
-    protected final T bufferConfig;
+    protected final Config bufferConfig;
     protected final ThreadLocal<ObjectMapper> objectMapperHolder = new ThreadLocal<ObjectMapper>() {
         @Override
         protected ObjectMapper initialValue()
@@ -37,7 +36,7 @@ public abstract class Buffer<T extends Buffer.Config>
     };
     protected final FileBackup fileBackup;
 
-    public Buffer(T bufferConfig)
+    public Buffer(Config bufferConfig)
     {
         this.bufferConfig = bufferConfig;
         if (bufferConfig.getFileBackupDir() != null) {
@@ -46,6 +45,11 @@ public abstract class Buffer<T extends Buffer.Config>
         else {
             fileBackup = null;
         }
+    }
+
+    protected Config getConfig()
+    {
+        return bufferConfig;
     }
 
     public void init()
@@ -131,22 +135,24 @@ public abstract class Buffer<T extends Buffer.Config>
         }
     }
 
-    public abstract static class Config<T extends Buffer, C extends Config>
+    public abstract static class Config<BufferImpl extends Buffer, ConfigImpl extends Config>
     {
         protected long maxBufferSize = 512 * 1024 * 1024;
         protected boolean ackResponseMode = false;
         protected String fileBackupDir;
         protected String fileBackupPrefix;  // Mainly for testing
 
+        protected abstract ConfigImpl self();
+
         public long getMaxBufferSize()
         {
             return maxBufferSize;
         }
 
-        public C setMaxBufferSize(long maxBufferSize)
+        public ConfigImpl setMaxBufferSize(long maxBufferSize)
         {
             this.maxBufferSize = maxBufferSize;
-            return (C)this;
+            return self();
         }
 
         public boolean isAckResponseMode()
@@ -154,10 +160,10 @@ public abstract class Buffer<T extends Buffer.Config>
             return ackResponseMode;
         }
 
-        public C setAckResponseMode(boolean ackResponseMode)
+        public ConfigImpl setAckResponseMode(boolean ackResponseMode)
         {
             this.ackResponseMode = ackResponseMode;
-            return (C)this;
+            return self();
         }
 
         public String getFileBackupDir()
@@ -165,10 +171,10 @@ public abstract class Buffer<T extends Buffer.Config>
             return fileBackupDir;
         }
 
-        public C setFileBackupDir(String fileBackupDir)
+        public ConfigImpl setFileBackupDir(String fileBackupDir)
         {
             this.fileBackupDir = fileBackupDir;
-            return (C) this;
+            return self();
         }
 
         public String getFileBackupPrefix()
@@ -176,10 +182,10 @@ public abstract class Buffer<T extends Buffer.Config>
             return fileBackupPrefix;
         }
 
-        public C setFileBackupPrefix(String fileBackupPrefix)
+        public ConfigImpl setFileBackupPrefix(String fileBackupPrefix)
         {
             this.fileBackupPrefix = fileBackupPrefix;
-            return (C) this;
+            return self();
         }
 
         @Override
@@ -193,11 +199,11 @@ public abstract class Buffer<T extends Buffer.Config>
                     '}';
         }
 
-        protected abstract T createInstanceInternal();
+        protected abstract BufferImpl createInstanceInternal();
 
-        public T createInstance()
+        public BufferImpl createInstance()
         {
-            T instance = createInstanceInternal();
+            BufferImpl instance = createInstanceInternal();
             instance.init();
             return instance;
         }

--- a/src/main/java/org/komamitsu/fluency/buffer/Buffer.java
+++ b/src/main/java/org/komamitsu/fluency/buffer/Buffer.java
@@ -135,21 +135,21 @@ public abstract class Buffer
         }
     }
 
-    public abstract static class Config<BufferImpl extends Buffer, ConfigImpl extends Config>
+    public abstract static class Config<BufferImpl extends Buffer, BufferConfigImpl extends Buffer.Config<BufferImpl, BufferConfigImpl>>
     {
         protected long maxBufferSize = 512 * 1024 * 1024;
         protected boolean ackResponseMode = false;
         protected String fileBackupDir;
         protected String fileBackupPrefix;  // Mainly for testing
 
-        protected abstract ConfigImpl self();
+        protected abstract BufferConfigImpl self();
 
         public long getMaxBufferSize()
         {
             return maxBufferSize;
         }
 
-        public ConfigImpl setMaxBufferSize(long maxBufferSize)
+        public BufferConfigImpl setMaxBufferSize(long maxBufferSize)
         {
             this.maxBufferSize = maxBufferSize;
             return self();
@@ -160,7 +160,7 @@ public abstract class Buffer
             return ackResponseMode;
         }
 
-        public ConfigImpl setAckResponseMode(boolean ackResponseMode)
+        public BufferConfigImpl setAckResponseMode(boolean ackResponseMode)
         {
             this.ackResponseMode = ackResponseMode;
             return self();
@@ -171,7 +171,7 @@ public abstract class Buffer
             return fileBackupDir;
         }
 
-        public ConfigImpl setFileBackupDir(String fileBackupDir)
+        public BufferConfigImpl setFileBackupDir(String fileBackupDir)
         {
             this.fileBackupDir = fileBackupDir;
             return self();
@@ -182,7 +182,7 @@ public abstract class Buffer
             return fileBackupPrefix;
         }
 
-        public ConfigImpl setFileBackupPrefix(String fileBackupPrefix)
+        public BufferConfigImpl setFileBackupPrefix(String fileBackupPrefix)
         {
             this.fileBackupPrefix = fileBackupPrefix;
             return self();

--- a/src/main/java/org/komamitsu/fluency/flusher/Flusher.java
+++ b/src/main/java/org/komamitsu/fluency/flusher/Flusher.java
@@ -72,7 +72,7 @@ public abstract class Flusher
         buffer.close();
     }
 
-    public abstract static class Config<FlusherImpl extends Flusher, ConfigImpl extends Config>
+    public abstract static class Config<FlusherImpl extends Flusher, FlusherConfigImpl extends Flusher.Config<FlusherImpl, FlusherConfigImpl>>
     {
         private int flushIntervalMillis = 600;
 
@@ -83,7 +83,7 @@ public abstract class Flusher
             return flushIntervalMillis;
         }
 
-        public ConfigImpl setFlushIntervalMillis(int flushIntervalMillis)
+        public FlusherConfigImpl setFlushIntervalMillis(int flushIntervalMillis)
         {
             this.flushIntervalMillis = flushIntervalMillis;
             return self();
@@ -94,13 +94,13 @@ public abstract class Flusher
             return waitAfterClose;
         }
 
-        public ConfigImpl setWaitAfterClose(int waitAfterClose)
+        public FlusherConfigImpl setWaitAfterClose(int waitAfterClose)
         {
             this.waitAfterClose = waitAfterClose;
             return self();
         }
 
-        protected abstract ConfigImpl self();
+        protected abstract FlusherConfigImpl self();
         public abstract FlusherImpl createInstance(Buffer buffer, Sender sender);
     }
 }

--- a/src/main/java/org/komamitsu/fluency/flusher/Flusher.java
+++ b/src/main/java/org/komamitsu/fluency/flusher/Flusher.java
@@ -9,19 +9,23 @@ import java.io.Closeable;
 import java.io.Flushable;
 import java.io.IOException;
 
-public abstract class Flusher<C extends Flusher.Config>
+public abstract class Flusher
         implements Flushable, Closeable
 {
     private static final Logger LOG = LoggerFactory.getLogger(Flusher.class);
     protected final Buffer buffer;
     protected final Sender sender;
-    protected final C flusherConfig;
+    protected final Flusher.Config flusherConfig;
 
-    public Flusher(Buffer buffer, Sender sender, C flusherConfig)
+    public Flusher(Buffer buffer, Sender sender, Flusher.Config flusherConfig)
     {
         this.buffer = buffer;
         this.sender = sender;
         this.flusherConfig = flusherConfig;
+    }
+
+    protected Flusher.Config getConfig() {
+        return flusherConfig;
     }
 
     public Buffer getBuffer()
@@ -68,7 +72,7 @@ public abstract class Flusher<C extends Flusher.Config>
         buffer.close();
     }
 
-    public abstract static class Config<T extends Flusher, C extends Config>
+    public abstract static class Config<FlusherImpl extends Flusher, ConfigImpl extends Config>
     {
         private int flushIntervalMillis = 600;
 
@@ -79,10 +83,10 @@ public abstract class Flusher<C extends Flusher.Config>
             return flushIntervalMillis;
         }
 
-        public C setFlushIntervalMillis(int flushIntervalMillis)
+        public ConfigImpl setFlushIntervalMillis(int flushIntervalMillis)
         {
             this.flushIntervalMillis = flushIntervalMillis;
-            return (C)this;
+            return self();
         }
 
         public int getWaitAfterClose()
@@ -90,12 +94,13 @@ public abstract class Flusher<C extends Flusher.Config>
             return waitAfterClose;
         }
 
-        public C setWaitAfterClose(int waitAfterClose)
+        public ConfigImpl setWaitAfterClose(int waitAfterClose)
         {
             this.waitAfterClose = waitAfterClose;
-            return (C) this;
+            return self();
         }
 
-        public abstract T createInstance(Buffer buffer, Sender sender);
+        protected abstract ConfigImpl self();
+        public abstract FlusherImpl createInstance(Buffer buffer, Sender sender);
     }
 }

--- a/src/main/java/org/komamitsu/fluency/sender/MultiSender.java
+++ b/src/main/java/org/komamitsu/fluency/sender/MultiSender.java
@@ -17,7 +17,7 @@ import java.util.Arrays;
 import java.util.List;
 
 public class MultiSender
-        extends Sender<MultiSender.Config>
+        extends Sender
 {
     private static final Logger LOG = LoggerFactory.getLogger(MultiSender.class);
     @VisibleForTesting
@@ -39,6 +39,12 @@ public class MultiSender
             }
             sendersAndFailureDetectors.add(new Tuple<TCPSender, FailureDetector>(senderConfig.createInstance(), failureDetector));
         }
+    }
+
+    @Override
+    protected MultiSender.Config getConfig()
+    {
+        return (MultiSender.Config) config;
     }
 
     @Override
@@ -109,7 +115,7 @@ public class MultiSender
         }
     }
 
-    public static class Config extends Sender.Config<MultiSender, Config>
+    public static class Config extends Sender.Config<MultiSender, MultiSender.Config>
     {
         private final List<TCPSender.Config> senderConfigs;
         private FailureDetectStrategy.Config failureDetectStrategyConfig = new PhiAccrualFailureDetectStrategy.Config();
@@ -118,6 +124,12 @@ public class MultiSender
         public Config(List<TCPSender.Config> senderConfigs)
         {
             this.senderConfigs = senderConfigs;
+        }
+
+        @Override
+        protected Config self()
+        {
+            return this;
         }
 
         public List<TCPSender.Config> getSenderConfigs()

--- a/src/main/java/org/komamitsu/fluency/sender/RetryableSender.java
+++ b/src/main/java/org/komamitsu/fluency/sender/RetryableSender.java
@@ -13,12 +13,18 @@ import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 
 public class RetryableSender
-        extends Sender<RetryableSender.Config>
+        extends Sender
 {
     private static final Logger LOG = LoggerFactory.getLogger(RetryableSender.class);
     private final Sender baseSender;
     private RetryStrategy retryStrategy;
     private final AtomicBoolean isClosed = new AtomicBoolean();
+
+    @Override
+    protected RetryableSender.Config getConfig()
+    {
+        return (RetryableSender.Config) config;
+    }
 
     @Override
     public void close()
@@ -92,9 +98,15 @@ public class RetryableSender
                 "} " + super.toString();
     }
 
-    public static class Config extends Sender.Config<RetryableSender, Config>
+    public static class Config extends Sender.Config<RetryableSender, RetryableSender.Config>
     {
         private RetryStrategy.Config retryStrategyConfig = new ExponentialBackOffRetryStrategy.Config();
+
+        @Override
+        protected Config self()
+        {
+            return this;
+        }
 
         public Config(Sender.Config baseSenderConfig)
         {

--- a/src/main/java/org/komamitsu/fluency/sender/Sender.java
+++ b/src/main/java/org/komamitsu/fluency/sender/Sender.java
@@ -8,15 +8,17 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 
-public abstract class Sender<C extends Sender.Config>
+public abstract class Sender
     implements Closeable
 {
-    protected final C config;
+    protected final Config config;
 
-    protected Sender(C config)
+    protected Sender(Config config)
     {
         this.config = config;
     }
+
+    abstract protected Config getConfig();
 
     public synchronized void send(ByteBuffer data)
             throws IOException
@@ -70,8 +72,9 @@ public abstract class Sender<C extends Sender.Config>
 
     abstract protected void sendInternal(List<ByteBuffer> dataList, byte[] ackToken) throws IOException;
 
-    public abstract static class Config<T extends Sender, C extends Config>
+    public abstract static class Config<SenderImpl extends Sender, SenderConfigImpl extends Config<SenderImpl, SenderConfigImpl>>
     {
-        public abstract T createInstance();
+        protected abstract SenderConfigImpl self();
+        public abstract SenderImpl createInstance();
     }
 }

--- a/src/main/java/org/komamitsu/fluency/sender/heartbeat/Heartbeater.java
+++ b/src/main/java/org/komamitsu/fluency/sender/heartbeat/Heartbeater.java
@@ -96,7 +96,7 @@ public abstract class Heartbeater implements Closeable
         void onFailure(Throwable cause);
     }
 
-    public abstract static class Config<C extends Config>
+    public abstract static class Config<HeartbeaterConfigImpl extends Config>
     {
         private String host = "127.0.0.1";
         private int port = 24224;
@@ -107,10 +107,10 @@ public abstract class Heartbeater implements Closeable
             return host;
         }
 
-        public C setHost(String host)
+        public HeartbeaterConfigImpl setHost(String host)
         {
             this.host = host;
-            return (C)this;
+            return (HeartbeaterConfigImpl)this;
         }
 
         public int getPort()
@@ -118,10 +118,10 @@ public abstract class Heartbeater implements Closeable
             return port;
         }
 
-        public C setPort(int port)
+        public HeartbeaterConfigImpl setPort(int port)
         {
             this.port = port;
-            return (C)this;
+            return (HeartbeaterConfigImpl)this;
         }
 
         public int getIntervalMillis()
@@ -129,10 +129,10 @@ public abstract class Heartbeater implements Closeable
             return intervalMillis;
         }
 
-        public C setIntervalMillis(int intervalMillis)
+        public HeartbeaterConfigImpl setIntervalMillis(int intervalMillis)
         {
             this.intervalMillis = intervalMillis;
-            return (C)this;
+            return (HeartbeaterConfigImpl)this;
         }
 
         @Override
@@ -149,6 +149,6 @@ public abstract class Heartbeater implements Closeable
                 throws IOException;
 
         // TODO: Make it simpler
-        public abstract C dupDefaultConfig();
+        public abstract HeartbeaterConfigImpl dupDefaultConfig();
     }
 }

--- a/src/test/java/org/komamitsu/fluency/StubSender.java
+++ b/src/test/java/org/komamitsu/fluency/StubSender.java
@@ -5,14 +5,19 @@ import org.komamitsu.fluency.sender.Sender;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.List;
-import java.util.concurrent.CountDownLatch;
 
 public class StubSender
-        extends Sender<StubSender.Config>
+        extends Sender
 {
     public StubSender()
     {
         super(null);
+    }
+
+    @Override
+    protected StubSender.Config getConfig()
+    {
+        return (StubSender.Config) config;
     }
 
     @Override
@@ -30,6 +35,11 @@ public class StubSender
     public static class Config
             extends Sender.Config<StubSender, Config>
     {
+        @Override
+        protected Config self() {
+            return this;
+        }
+
         // Dummy
         @Override
         public StubSender createInstance()

--- a/src/test/java/org/komamitsu/fluency/buffer/TestableBuffer.java
+++ b/src/test/java/org/komamitsu/fluency/buffer/TestableBuffer.java
@@ -16,7 +16,7 @@ import java.util.Map;
 import java.util.concurrent.atomic.AtomicInteger;
 
 public class TestableBuffer
-        extends Buffer<TestableBuffer.Config>
+        extends Buffer
 {
     private static final Logger LOG = LoggerFactory.getLogger(TestableBuffer.class);
     public static final int RECORD_DATA_SIZE = 100;
@@ -33,6 +33,11 @@ public class TestableBuffer
     private TestableBuffer(Config bufferConfig)
     {
         super(bufferConfig);
+    }
+
+    @Override
+    protected TestableBuffer.Config getConfig() {
+        return (TestableBuffer.Config) bufferConfig;
     }
 
     public void setSavableBuffer(List<String> params, ByteBuffer buffer)
@@ -136,6 +141,11 @@ public class TestableBuffer
     public static class Config
             extends Buffer.Config<TestableBuffer, Config>
     {
+        @Override
+        protected TestableBuffer.Config self() {
+            return this;
+        }
+
         @Override
         protected TestableBuffer createInstanceInternal()
         {


### PR DESCRIPTION
This PR removes generic interfaces from Buffer, Sender and Flusher. This change does not break existing Fluency APIs, so no test (or user) code change is required.

**Background**
We are trying to use Fluency in a Scala project, but encountered a tricky error when evaluating Scala code that uses Fluency at runtime: https://github.com/wvlet/wvlet/pull/8

```
[info]   scala.reflect.internal.Symbols$CyclicReference: illegal cyclic reference involving type C
```

This happens because there are complex cyclic references of generic types:
```
Buffer<T> { ...  Buffer.Config<T extends Buffer, C extends Config> }
```

Buffer references Config, which also checks parent Buffer and self Config type. This compiles in Java, but when using from scalac with reflective compilation (runtime eval of Scala code), the cyclic reference causes the above error. 

More accurately, this type definition needs to be:
```
Buffer<T> { ... Buffer.Config<T extends Buffer<T>, C extends Config<T, C> }
```

But this adds the complexity to the code, so I simplified the interface structures by removing generics, and introduced `ConfigImpl getConfig()` to get Buffer/Sender/Flusher specific configurations. 

