### PR TITLE
Add shadow jar to avoid jackson version incompatibility

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -4,6 +4,7 @@ apply plugin: 'jacoco'
 apply plugin: 'maven'
 apply plugin: 'signing'
 apply plugin: 'com.github.kt3k.coveralls'
+apply plugin: 'com.github.johnrengelman.shadow'
 
 
 group = 'org.komamitsu'
@@ -34,6 +35,11 @@ findbugs {
     effort = 'max'
 }
 
+shadowJar {
+    relocate 'com.fasterxml.jackson', 'org.komamitsu.thirdparty.jackson'
+    classifier = 'shadow'
+}
+
 tasks.withType(FindBugs) {
     reports {
         xml.enabled = false
@@ -52,7 +58,7 @@ task sourcesJar(type: Jar) {
 }
 
 artifacts {
-    archives javadocJar, sourcesJar
+    archives javadocJar, sourcesJar, shadowJar
 }
 
 signing {
@@ -105,10 +111,12 @@ uploadArchives {
 buildscript {
     repositories {
         mavenCentral()
+        jcenter()
     }
 
     dependencies {
         classpath 'org.kt3k.gradle.plugin:coveralls-gradle-plugin:2.0.1'
+        classpath 'com.github.jengelman.gradle.plugins:shadow:1.2.3'
     }
 }
 


### PR DESCRIPTION
Fluency uses jackson 2.7.x and it causes conflict with these projects: 
- Finagle uses 2.6.5: https://github.com/twitter/finagle/blob/ca4c237bf550cb0856e140d2b73b6168d325c089/project/Build.scala#L36
- Presto uses 2.4.4: https://github.com/airlift/airbase/blob/240f27ee54ca0b4259e49740fb41acd9eb2dac1d/pom.xml#L148

To use fluency with these projects, we should relocate the jackson to another package. This PR creates fluency-shadow.jar, which contains all dependent jars and relocated jackson libraries.
