### PR TITLE
add support for nanosecond timestamps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 1.1.0-SNAPSHOT (unreleased)
+
+Requires fluentd >= 0.14
+
+Features:
+
+- Add support for nanosecond timestamps
+
 ## 1.0.0 (2016-09-19)
 
 Features:

--- a/src/main/java/org/komamitsu/fluency/Fluency.java
+++ b/src/main/java/org/komamitsu/fluency/Fluency.java
@@ -10,6 +10,7 @@ import org.komamitsu.fluency.sender.Sender;
 import org.komamitsu.fluency.sender.TCPSender;
 import org.komamitsu.fluency.sender.heartbeat.TCPHeartbeater;
 import org.komamitsu.fluency.sender.retry.ExponentialBackOffRetryStrategy;
+import org.komamitsu.fluency.util.EventTime;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -150,8 +151,15 @@ public class Fluency
     public void emit(String tag, long timestamp, Map<String, Object> data)
             throws IOException
     {
+        // the typecast is not nice, but unfortunately required due to their EvenTime specification
+        emit(tag, EventTime.fromTimestamp((int)timestamp), data);
+    }
+
+    public void emit(String tag, EventTime eventTime, Map<String, Object> data)
+            throws IOException
+    {
         try {
-            buffer.append(tag, timestamp, data);
+            buffer.append(tag, eventTime, data);
             flusher.onUpdate();
         }
         catch (BufferFullException e) {
@@ -164,7 +172,7 @@ public class Fluency
     public void emit(String tag, Map<String, Object> data)
             throws IOException
     {
-        emit(tag, System.currentTimeMillis() / 1000, data);
+        emit(tag, EventTime.fromMillis(System.currentTimeMillis()), data);
     }
 
     @Override

--- a/src/main/java/org/komamitsu/fluency/Fluency.java
+++ b/src/main/java/org/komamitsu/fluency/Fluency.java
@@ -151,8 +151,7 @@ public class Fluency
     public void emit(String tag, long timestamp, Map<String, Object> data)
             throws IOException
     {
-        // the typecast is not nice, but unfortunately required due to their EvenTime specification
-        emit(tag, EventTime.fromTimestamp((int)timestamp), data);
+        emit(tag, EventTime.fromTimestamp(timestamp), data);
     }
 
     public void emit(String tag, EventTime eventTime, Map<String, Object> data)

--- a/src/main/java/org/komamitsu/fluency/buffer/Buffer.java
+++ b/src/main/java/org/komamitsu/fluency/buffer/Buffer.java
@@ -3,6 +3,7 @@ package org.komamitsu.fluency.buffer;
 import com.fasterxml.jackson.databind.Module;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.komamitsu.fluency.sender.Sender;
+import org.komamitsu.fluency.util.EventTime;
 import org.msgpack.jackson.dataformat.MessagePackFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -57,7 +58,7 @@ public abstract class Buffer
         }
     }
 
-    public abstract void append(String tag, long timestamp, Map<String, Object> data)
+    public abstract void append(String tag, EventTime eventTime, Map<String, Object> data)
             throws IOException;
 
     protected abstract void loadBufferFromFile(List<String> params, FileChannel channel);

--- a/src/main/java/org/komamitsu/fluency/buffer/PackedForwardBuffer.java
+++ b/src/main/java/org/komamitsu/fluency/buffer/PackedForwardBuffer.java
@@ -3,6 +3,7 @@ package org.komamitsu.fluency.buffer;
 import com.fasterxml.jackson.databind.Module;
 import org.komamitsu.fluency.BufferFullException;
 import org.komamitsu.fluency.sender.Sender;
+import org.komamitsu.fluency.util.EventTime;
 import org.msgpack.core.MessagePack;
 import org.msgpack.core.MessagePacker;
 import org.slf4j.Logger;
@@ -134,12 +135,12 @@ public class PackedForwardBuffer
     }
 
     @Override
-    public void append(String tag, long timestamp, Map<String, Object> data)
+    public void append(String tag, EventTime eventTime, Map<String, Object> data)
             throws IOException
     {
         ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
         outputStream.reset();
-        objectMapper.writeValue(outputStream, Arrays.asList(timestamp, data));
+        objectMapper.writeValue(outputStream, Arrays.asList(eventTime.pack(), data));
         outputStream.close();
 
         loadDataToRetentionBuffers(tag, ByteBuffer.wrap(outputStream.toByteArray()));

--- a/src/main/java/org/komamitsu/fluency/util/EventTime.java
+++ b/src/main/java/org/komamitsu/fluency/util/EventTime.java
@@ -34,6 +34,10 @@ public class EventTime implements Serializable {
         return new EventTime((int)(timeInMillis / 1000), (int)(timeInMillis % 1000 * 1000000));
     }
 
+    public long inMillis() {
+        return (long)this.seconds * 1000 + (long)this.nanoseconds / 1000000;
+    }
+
     public MessagePackExtensionType pack() {
         // https://github.com/fluent/fluentd/wiki/Forward-Protocol-Specification-v1 => EventTime Ext Format
         /*

--- a/src/main/java/org/komamitsu/fluency/util/EventTime.java
+++ b/src/main/java/org/komamitsu/fluency/util/EventTime.java
@@ -1,0 +1,101 @@
+package org.komamitsu.fluency.util;
+
+import org.msgpack.core.*;
+
+import java.io.IOException;
+import java.io.Serializable;
+
+/**
+ * Implementation of Fluentd EventTime
+ * This is susceptible to integer overruns and also affected by the 2038 problem, but so is their spec
+ * They use ints internally, so must we
+ */
+public class EventTime implements Serializable {
+
+    int seconds;
+    int nanoseconds;
+
+    public EventTime(int seconds, int nanoseconds) {
+        this.seconds = seconds;
+        this.nanoseconds = nanoseconds;
+    }
+
+    public static EventTime fromTimestamp(int timestamp) {
+        return new EventTime(timestamp, 0);
+    }
+
+    public static EventTime fromTimestamp(long timestamp) {
+        // the lossy cast is unfortunately required due to their spec
+        return new EventTime((int)timestamp, 0);
+    }
+
+    public static EventTime fromMillis(long timeInMillis) {
+        return new EventTime((int)(timeInMillis / 1000), (int)(timeInMillis % 1000 * 1000000));
+    }
+
+    public byte[] pack() throws IOException {
+        MessageBufferPacker packer = MessagePack.newDefaultBufferPacker();
+
+        // https://github.com/fluent/fluentd/wiki/Forward-Protocol-Specification-v1 => EventTime Ext Format
+        /*
+           +-------+----+----+----+----+----+----+----+----+----+
+           |     1 |  2 |  3 |  4 |  5 |  6 |  7 |  8 |  9 | 10 |
+           +-------+----+----+----+----+----+----+----+----+----+
+           |    D7 | 00 | second from epoch |     nanosecond    |
+           +-------+----+----+----+----+----+----+----+----+----+
+           |fixext8|type| 32bits integer BE | 32bits integer BE |
+           +-------+----+----+----+----+----+----+----+----+----+
+         */
+        packer.packExtensionTypeHeader((byte) 0, 8);
+        packer.packInt((int)this.seconds);
+        packer.packInt((int)this.nanoseconds);
+
+        return packer.toByteArray();
+    }
+
+    public static EventTime unpack(byte[] message) {
+        MessageUnpacker unpacker = MessagePack.newDefaultUnpacker(message);
+
+        int seconds;
+        int nanoseconds;
+
+        try {
+            if (!unpacker.getNextFormat().equals(MessageFormat.FIXEXT8)) return null;
+            if (unpacker.unpackExtensionTypeHeader().getType() != 0x0)   return null;
+
+            seconds = unpacker.unpackInt();
+            nanoseconds = unpacker.unpackInt();
+        } catch (IOException e) {
+            return null;
+        }
+
+        return new EventTime(seconds, nanoseconds);
+    }
+
+    @Override
+    public String toString() {
+        return "EventTime{" +
+                "seconds=" + seconds +
+                ", nanoseconds=" + nanoseconds +
+                '}';
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+
+        EventTime eventTime = (EventTime) o;
+
+        if (seconds != eventTime.seconds) return false;
+        return nanoseconds == eventTime.nanoseconds;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = seconds;
+        result = 31 * result + nanoseconds;
+        return result;
+    }
+
+}

--- a/src/main/java/org/komamitsu/fluency/util/EventTime.java
+++ b/src/main/java/org/komamitsu/fluency/util/EventTime.java
@@ -1,6 +1,7 @@
 package org.komamitsu.fluency.util;
 
 import org.msgpack.jackson.dataformat.MessagePackExtensionType;
+import org.msgpack.value.ExtensionValue;
 
 import java.io.Serializable;
 import java.nio.ByteBuffer;
@@ -45,6 +46,39 @@ public class EventTime implements Serializable {
            +-------+----+----+----+----+----+----+----+----+----+
          */
         return new MessagePackExtensionType((byte)0x0, ByteBuffer.allocate(8).putInt(this.seconds).putInt(this.nanoseconds).array());
+    }
+
+    public static EventTime unpack(ExtensionValue packed) {
+
+        /*
+        The fixext8 header gets stripped before, so we can just verify the type and fetch both values
+           +-------+----+----+----+----+----+----+----+----+----+
+           |     1 |  2 |  3 |  4 |  5 |  6 |  7 |  8 |  9 | 10 |
+           +-------+----+----+----+----+----+----+----+----+----+
+           |    D7 | 00 | second from epoch |     nanosecond    |
+           +-------+----+----+----+----+----+----+----+----+----+
+           |fixext8|type| 32bits integer BE | 32bits integer BE |
+           +-------+----+----+----+----+----+----+----+----+----+
+        */
+        if (packed.getType() != 0x0) {
+            return null;
+        }
+
+        if (packed.getData().length != 8) {
+            return null;
+        }
+
+        ByteBuffer data = ByteBuffer.wrap(packed.getData());
+
+        return new EventTime(data.getInt(0), data.getInt(4));
+    }
+
+    public int getSeconds() {
+        return seconds;
+    }
+
+    public void setSeconds(int seconds) {
+        this.seconds = seconds;
     }
 
     @Override

--- a/src/test/java/org/komamitsu/fluency/FluencyTest.java
+++ b/src/test/java/org/komamitsu/fluency/FluencyTest.java
@@ -24,6 +24,7 @@ import org.komamitsu.fluency.sender.failuredetect.FailureDetector;
 import org.komamitsu.fluency.sender.failuredetect.PhiAccrualFailureDetectStrategy;
 import org.komamitsu.fluency.sender.heartbeat.TCPHeartbeater;
 import org.komamitsu.fluency.sender.retry.ExponentialBackOffRetryStrategy;
+import org.komamitsu.fluency.util.EventTime;
 import org.msgpack.value.MapValue;
 import org.msgpack.value.Value;
 import org.slf4j.Logger;
@@ -806,7 +807,7 @@ public class FluencyTest
                 }
 
                 @Override
-                public void onReceive(String tag, long timestampMillis, MapValue data)
+                public void onReceive(String tag, EventTime eventTime, MapValue data)
                 {
                     if (tag.equals("foodb0.bartbl0")) {
                         tag0EventsCounter.incrementAndGet();
@@ -823,7 +824,7 @@ public class FluencyTest
                     else {
                         throw new IllegalArgumentException("Unexpected tag: tag=" + tag);
                     }
-                    assertTrue(startTimestamp <= timestampMillis && timestampMillis < startTimestamp + 60 * 1000);
+                    assertTrue(startTimestamp <= eventTime.getSeconds() && eventTime.getSeconds() < startTimestamp + 60 * 1000);
 
                     assertEquals(4, data.size());
                     for (Map.Entry<Value, Value> kv : data.entrySet()) {

--- a/src/test/java/org/komamitsu/fluency/FluencyTest.java
+++ b/src/test/java/org/komamitsu/fluency/FluencyTest.java
@@ -933,7 +933,7 @@ public class FluencyTest
             Fluency fluency = new Fluency.Builder(stuckSender).setBufferConfig(bufferConfig).build();
             Map<String, Object> event = new HashMap<String, Object>();
             event.put("name", "xxxx");
-            for (int i = 0; i < 7; i++) {
+            for (int i = 0; i < 5; i++) {
                 fluency.emit("tag", event);
             }
             try {

--- a/src/test/java/org/komamitsu/fluency/buffer/BufferTest.java
+++ b/src/test/java/org/komamitsu/fluency/buffer/BufferTest.java
@@ -2,6 +2,8 @@ package org.komamitsu.fluency.buffer;
 
 import org.junit.Test;
 import org.komamitsu.fluency.StubSender;
+import org.komamitsu.fluency.util.EventTime;
+import org.komamitsu.fluency.util.EventTimeTest;
 import org.komamitsu.fluency.util.Tuple;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -30,13 +32,13 @@ public class BufferTest
         HashMap<String, Object> data = new HashMap<String, Object>();
         data.put("name", "komamitsu");
         for (int i = 0; i < 10; i++) {
-            buffer.append("foodb.bartbl" + i, 1420070400, data);
+            buffer.append("foodb.bartbl" + i, EventTime.fromTimestamp(1420070400), data);
         }
         assertEquals(TestableBuffer.ALLOC_SIZE * 10, buffer.getAllocatedSize());
         assertEquals(TestableBuffer.RECORD_DATA_SIZE * 10, buffer.getBufferedDataSize());
         assertEquals(TestableBuffer.ALLOC_SIZE * 10 / 10000f, buffer.getBufferUsage(), 0.001);
         for (int i = 0; i < 10; i++) {
-            buffer.append("foodb.bartbl" + i, 1420070400, data);
+            buffer.append("foodb.bartbl" + i, EventTime.fromTimestamp(1420070400), data);
         }
         assertEquals(TestableBuffer.ALLOC_SIZE * 20, buffer.getAllocatedSize());
         assertEquals(TestableBuffer.RECORD_DATA_SIZE * 20, buffer.getBufferedDataSize());

--- a/src/test/java/org/komamitsu/fluency/buffer/BufferTestHelper.java
+++ b/src/test/java/org/komamitsu/fluency/buffer/BufferTestHelper.java
@@ -5,9 +5,12 @@ import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.komamitsu.fluency.sender.MockTCPSender;
 import org.komamitsu.fluency.util.EventTime;
+import org.msgpack.core.MessageFormat;
+import org.msgpack.core.MessageFormatException;
 import org.msgpack.core.MessagePack;
 import org.msgpack.core.MessageUnpacker;
 import org.msgpack.jackson.dataformat.MessagePackFactory;
+import org.msgpack.value.ExtensionValue;
 import org.msgpack.value.ImmutableValue;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -171,7 +174,10 @@ public class BufferTestHelper
                 while (messageUnpacker.hasNext()) {
                     assertEquals(2, messageUnpacker.unpackArrayHeader());
 
-                    long timestamp = messageUnpacker.unpackLong();
+                    if (messageUnpacker.getNextFormat() != MessageFormat.FIXEXT8) {
+                        throw new MessageFormatException("expected Extension - got " + messageUnpacker.getNextFormat());
+                    }
+                    EventTime eventTime = EventTime.unpack(messageUnpacker.unpackValue().asExtensionValue());
 
                     int size = messageUnpacker.unpackMapHeader();
                     assertEquals(3, size);
@@ -187,7 +193,7 @@ public class BufferTestHelper
                         }
                     }
 
-                    analyzeResult(tag, timestamp, data, start, end);
+                    analyzeResult(tag, eventTime, data, start, end);
                     recordCount++;
                 }
             }
@@ -199,13 +205,13 @@ public class BufferTestHelper
                 assertTrue(items.get(0) instanceof String);
                 String tag = (String) items.get(0);
 
-                assertTrue(items.get(1) instanceof Long);
-                long timestamp = (Long) items.get(1);
+                assertTrue(items.get(1) instanceof ExtensionValue);
+                EventTime eventTime = EventTime.unpack((ExtensionValue)items.get(1));
 
                 assertTrue(items.get(2) instanceof Map);
                 Map<String, Object> data = (Map<String, Object>) items.get(2);
 
-                analyzeResult(tag, timestamp, data, start, end);
+                analyzeResult(tag, eventTime, data, start, end);
                 recordCount++;
             }
         }
@@ -233,7 +239,7 @@ public class BufferTestHelper
         assertTrue(totalLoopCount / 31 - 5 <= longCommentCount && longCommentCount <= totalLoopCount / 31 + 5);
     }
 
-    private void analyzeResult(String tag, long timestamp, Map<String, Object> data, long start, long end)
+    private void analyzeResult(String tag, EventTime eventTime, Map<String, Object> data, long start, long end)
     {
         Integer count = tagCounts.get(tag);
         if (count == null) {
@@ -241,7 +247,7 @@ public class BufferTestHelper
         }
         tagCounts.put(tag, count + 1);
 
-        assertTrue(start <= timestamp && timestamp <= end);
+        assertTrue(start <= eventTime.inMillis() && eventTime.inMillis() <= end);
 
         assertEquals(3, data.size());
         String name = (String) data.get("name");

--- a/src/test/java/org/komamitsu/fluency/buffer/BufferTestHelper.java
+++ b/src/test/java/org/komamitsu/fluency/buffer/BufferTestHelper.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.core.JsonParser;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import org.komamitsu.fluency.sender.MockTCPSender;
+import org.komamitsu.fluency.util.EventTime;
 import org.msgpack.core.MessagePack;
 import org.msgpack.core.MessageUnpacker;
 import org.msgpack.jackson.dataformat.MessagePackFactory;
@@ -11,7 +12,6 @@ import org.msgpack.value.ImmutableValue;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.HashMap;
@@ -76,7 +76,7 @@ public class BufferTestHelper
                         data.put("age", i);
                         data.put("comment", i % 31 == 0 ? longStr : "hello");
                         String tag = multiTags ? String.format("foodb%d.bartbl%d", i % 4, i % 4) : "foodb.bartbl";
-                        buffer.append(tag, System.currentTimeMillis(), data);
+                        buffer.append(tag, EventTime.fromMillis(System.currentTimeMillis()), data);
 
                         if (syncFlush) {
                             if (i % 20 == 0) {

--- a/src/test/java/org/komamitsu/fluency/buffer/PackedForwardBufferTest.java
+++ b/src/test/java/org/komamitsu/fluency/buffer/PackedForwardBufferTest.java
@@ -2,6 +2,7 @@ package org.komamitsu.fluency.buffer;
 
 import org.junit.Test;
 import org.komamitsu.fluency.sender.MockTCPSender;
+import org.komamitsu.fluency.util.EventTime;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -37,7 +38,7 @@ public class PackedForwardBufferTest
         Map<String, Object> map = new HashMap<String, Object>();
         map.put("name", "komamitsu");
         for (int i = 0; i < 10; i++) {
-            buffer.append("foo.bar", new Date().getTime(), map);
+            buffer.append("foo.bar", EventTime.fromTimestamp(new Date().getTime()), map);
         }
         assertThat(buffer.getAllocatedSize(), is(256 * 1024L));
     }
@@ -52,7 +53,7 @@ public class PackedForwardBufferTest
         Map<String, Object> map = new HashMap<String, Object>();
         map.put("name", "komamitsu");
         for (int i = 0; i < 10; i++) {
-            buffer.append("foo.bar", new Date().getTime(), map);
+            buffer.append("foo.bar", EventTime.fromTimestamp(new Date().getTime()), map);
         }
         assertThat(buffer.getBufferedDataSize(), is(greaterThan(0L)));
         assertThat(buffer.getBufferedDataSize(), is(lessThan(512L)));
@@ -83,13 +84,13 @@ public class PackedForwardBufferTest
         {
             Map<String, Object> map = new HashMap<String, Object>();
             map.put("k", str60kb);
-            buffer.append("tag0", new Date().getTime(), map);
+            buffer.append("tag0", EventTime.fromTimestamp(new Date().getTime()), map);
         }
 
         {
             Map<String, Object> map = new HashMap<String, Object>();
             map.put("k", str100kb);
-            buffer.append("tag0", new Date().getTime(), map);
+            buffer.append("tag0", EventTime.fromTimestamp(new Date().getTime()), map);
         }
     }
 }

--- a/src/test/java/org/komamitsu/fluency/buffer/TestableBuffer.java
+++ b/src/test/java/org/komamitsu/fluency/buffer/TestableBuffer.java
@@ -2,6 +2,7 @@ package org.komamitsu.fluency.buffer;
 
 import com.fasterxml.jackson.databind.Module;
 import org.komamitsu.fluency.sender.Sender;
+import org.komamitsu.fluency.util.EventTime;
 import org.komamitsu.fluency.util.Tuple;
 import org.komamitsu.fluency.util.Tuple3;
 import org.slf4j.Logger;
@@ -23,7 +24,7 @@ public class TestableBuffer
     private static final Logger LOG = LoggerFactory.getLogger(TestableBuffer.class);
     public static final int RECORD_DATA_SIZE = 100;
     public static final int ALLOC_SIZE = 128;
-    private final List<Tuple3<String, Long, Map<String, Object>>> events = new ArrayList<Tuple3<String, Long, Map<String, Object>>>();
+    private final List<Tuple3<String, EventTime, Map<String, Object>>> events = new ArrayList<Tuple3<String, EventTime, Map<String, Object>>>();
     private final AtomicInteger flushCount = new AtomicInteger();
     private final AtomicInteger forceFlushCount = new AtomicInteger();
     private final AtomicInteger closeCount = new AtomicInteger();
@@ -66,10 +67,10 @@ public class TestableBuffer
     }
 
     @Override
-    public void append(String tag, long timestamp, Map data)
+    public void append(String tag, EventTime eventTime, Map data)
             throws IOException
     {
-        events.add(new Tuple3<String, Long, Map<String, Object>>(tag, timestamp, data));
+        events.add(new Tuple3<String, EventTime, Map<String, Object>>(tag, eventTime, data));
         allocatedSize.addAndGet(ALLOC_SIZE);
         bufferedDataSize.addAndGet(RECORD_DATA_SIZE);
     }
@@ -129,7 +130,7 @@ public class TestableBuffer
         return bufferedDataSize.get();
     }
 
-    public List<Tuple3<String, Long, Map<String, Object>>> getEvents()
+    public List<Tuple3<String, EventTime, Map<String, Object>>> getEvents()
     {
         return events;
     }

--- a/src/test/java/org/komamitsu/fluency/util/EventTimeTest.java
+++ b/src/test/java/org/komamitsu/fluency/util/EventTimeTest.java
@@ -1,0 +1,79 @@
+package org.komamitsu.fluency.util;
+
+import org.junit.Test;
+import org.msgpack.core.MessageFormat;
+import org.msgpack.core.MessagePack;
+import org.msgpack.core.MessageUnpacker;
+
+import java.io.IOException;
+
+import static org.junit.Assert.assertEquals;
+
+
+public class EventTimeTest {
+
+    @Test
+    public void testTimeMillis() {
+
+        long fixedTimeMillis = 1483457616859L;
+
+        EventTime time = EventTime.fromMillis(fixedTimeMillis);
+
+        assertEquals(1483457616, time.seconds);
+        assertEquals(859000000, time.nanoseconds);
+    }
+
+    @Test
+    public void testTimestamp() {
+
+        int fixedTimestamp = 1483457616;
+
+        EventTime time = EventTime.fromTimestamp(fixedTimestamp);
+
+        assertEquals(1483457616, time.seconds);
+        assertEquals(0, time.nanoseconds);
+    }
+
+    // test if the message format is according to spec and that packing/unpacking is working correctly
+    @Test
+    public void testPacking() {
+
+        long fixedTimeMillis = 1483457616859L;
+
+        EventTime time = EventTime.fromMillis(fixedTimeMillis);
+
+        Exception ex = null;
+        byte[] packed;
+
+        try {
+            packed = time.pack();
+
+            MessageUnpacker unpacker = MessagePack.newDefaultUnpacker(packed);
+
+            /*
+               +-------+----+----+----+----+----+----+----+----+----+
+               |     1 |  2 |  3 |  4 |  5 |  6 |  7 |  8 |  9 | 10 |
+               +-------+----+----+----+----+----+----+----+----+----+
+               |    D7 | 00 | second from epoch |     nanosecond    |
+               +-------+----+----+----+----+----+----+----+----+----+
+               |fixext8|type| 32bits integer BE | 32bits integer BE |
+               +-------+----+----+----+----+----+----+----+----+----+
+             */
+            assertEquals(MessageFormat.FIXEXT8, unpacker.getNextFormat());
+            assertEquals(0x0, unpacker.unpackExtensionTypeHeader().getType());
+
+            assertEquals(time.seconds, unpacker.unpackInt());
+            assertEquals(time.nanoseconds, unpacker.unpackInt());
+
+            assertEquals(false, unpacker.hasNext());
+
+            assertEquals(time, EventTime.unpack(packed));
+
+        } catch (IOException e) {
+            ex = e;
+        }
+
+        assertEquals(null, ex);
+    }
+
+}


### PR DESCRIPTION
- new feature of fluentd 0.14
- internally switches everything to EventTime
- no breaking change