### PR TITLE
Fix a bug that Fluency with SyncFlusher doesn't flush without manually calling flush()

### DIFF
--- a/src/test/java/org/komamitsu/fluency/FluencyTest.java
+++ b/src/test/java/org/komamitsu/fluency/FluencyTest.java
@@ -167,7 +167,7 @@ public class FluencyTest
                 assertThat(buffer.getChunkExpandRatio(), is(2f));
                 assertThat(buffer.getChunkRetentionSize(), is(4 * 1024 * 1024));
                 assertThat(buffer.getChunkInitialSize(), is(1 * 1024 * 1024));
-                assertThat(buffer.getChunkRetentionTimeMillis(), is(400));
+                assertThat(buffer.getChunkRetentionTimeMillis(), is(1000));
                 assertThat(buffer.getJvmHeapBufferMode(), is(false));
                 assertThat(buffer.isAckResponseMode(), is(false));
 
@@ -242,7 +242,7 @@ public class FluencyTest
                 assertThat(buffer.getMaxBufferSize(), is(Long.MAX_VALUE));
                 assertThat(buffer.getFileBackupDir(), is(tmpdir));
                 assertThat(buffer.bufferFormatType(), is("packed_forward"));
-                assertThat(buffer.getChunkRetentionTimeMillis(), is(400));
+                assertThat(buffer.getChunkRetentionTimeMillis(), is(1000));
                 assertThat(buffer.getChunkExpandRatio(), is(2f));
                 assertThat(buffer.getChunkInitialSize(), is(7 * 1024 * 1024));
                 assertThat(buffer.getChunkRetentionSize(), is(13 * 1024 * 1024));

--- a/src/test/java/org/komamitsu/fluency/buffer/BufferTestHelper.java
+++ b/src/test/java/org/komamitsu/fluency/buffer/BufferTestHelper.java
@@ -15,7 +15,6 @@ import org.slf4j.LoggerFactory;
 
 import java.io.IOException;
 import java.nio.ByteBuffer;
-import java.nio.ByteOrder;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.CountDownLatch;
@@ -82,12 +81,6 @@ public class BufferTestHelper
                         }
                         else {
                             buffer.append(tag, System.currentTimeMillis(), data);
-                        }
-
-                        if (syncFlush) {
-                            if (i % 20 == 0) {
-                                buffer.flush(sender, false);
-                            }
                         }
                     }
                     latch.countDown();


### PR DESCRIPTION
when adding small amount of events repeatedly at short interval