### PR TITLE
Fix default maxBufferSize in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ dependencies {
 //   - Flush interval is 600ms (by default)
 //   - Initial chunk buffer size is 1MB (by default)
 //   - Threshold chunk buffer size to flush is 4MB (by default)
-//   - Max total buffer size is 16MB (by default)
+//   - Max total buffer size is 512MB (by default)
 //   - Use off heap memory for buffer pool (by default)
 //   - Max retry of sending events is 8 (by default)
 //   - Max wait until all buffers are flushed is 10 seconds (by default)


### PR DESCRIPTION
Fix default maxBufferSize in README.md.

16MB -> 512MB

It appears that the default value was changed, but README wasn't updated.

https://github.com/komamitsu/fluency/commit/1d7c1b091325cbc04ff4a071ae80fbee23087445#diff-a491243d703f407a1e7f65f3c9a5fe1bL87