### PR TITLE
Downgrade log levels for messages relating to buffers from info to debug

### DIFF
--- a/src/main/java/org/komamitsu/fluency/Fluency.java
+++ b/src/main/java/org/komamitsu/fluency/Fluency.java
@@ -357,7 +357,7 @@ public class Fluency
         int intervalMilli = 500;
         for (int i = 0; i < maxWaitSeconds * (1000 / intervalMilli); i++) {
             long bufferedDataSize = getBufferedDataSize();
-            LOG.info("Waiting for flushing all buffer: {}", bufferedDataSize);
+            LOG.debug("Waiting for flushing all buffer: {}", bufferedDataSize);
             if (getBufferedDataSize() == 0) {
                 return true;
             }
@@ -373,7 +373,7 @@ public class Fluency
         int intervalMilli = 500;
         for (int i = 0; i < maxWaitSeconds * (1000 / intervalMilli); i++) {
             boolean terminated = isTerminated();
-            LOG.info("Waiting until the flusher is terminated: {}", terminated);
+            LOG.debug("Waiting until the flusher is terminated: {}", terminated);
             if (terminated) {
                 return true;
             }

--- a/src/main/java/org/komamitsu/fluency/buffer/Buffer.java
+++ b/src/main/java/org/komamitsu/fluency/buffer/Buffer.java
@@ -50,7 +50,7 @@ public abstract class Buffer
                     @Override
                     public void process(List<String> params, FileChannel channel)
                     {
-                        LOG.debug("Loading buffer: params={}, buffer={}", params, channel);
+                        LOG.info("Loading buffer: params={}, buffer={}", params, channel);
                         loadBufferFromFile(params, channel);
                     }
                 });
@@ -86,7 +86,7 @@ public abstract class Buffer
         if (fileBackup == null) {
             return;
         }
-        LOG.debug("Saving buffer: params={}, buffer={}", params, buffer);
+        LOG.info("Saving buffer: params={}, buffer={}", params, buffer);
         fileBackup.saveBuffer(params, buffer);
     }
 

--- a/src/main/java/org/komamitsu/fluency/buffer/Buffer.java
+++ b/src/main/java/org/komamitsu/fluency/buffer/Buffer.java
@@ -50,7 +50,7 @@ public abstract class Buffer
                     @Override
                     public void process(List<String> params, FileChannel channel)
                     {
-                        LOG.info("Loading buffer: params={}, buffer={}", params, channel);
+                        LOG.debug("Loading buffer: params={}, buffer={}", params, channel);
                         loadBufferFromFile(params, channel);
                     }
                 });
@@ -86,7 +86,7 @@ public abstract class Buffer
         if (fileBackup == null) {
             return;
         }
-        LOG.info("Saving buffer: params={}, buffer={}", params, buffer);
+        LOG.debug("Saving buffer: params={}, buffer={}", params, buffer);
         fileBackup.saveBuffer(params, buffer);
     }
 
@@ -105,13 +105,13 @@ public abstract class Buffer
     public void close()
     {
         try {
-            LOG.info("Saving all buffers");
+            LOG.debug("Saving all buffers");
             saveAllBuffersToFile();
         }
         catch (Exception e) {
             LOG.warn("Failed to save all buffers", e);
         }
-        LOG.info("Closing buffers");
+        LOG.debug("Closing buffers");
         closeInternal();
     }
 


### PR DESCRIPTION
Annoying to have log messages printed for what seem like normal and unremarkable events. Encountered in https://github.com/jenkinsci/pipeline-log-fluentd-cloudwatch-plugin/pull/5 as pairs of messages for every `Buffer.close`. CC @carlossg