### PR TITLE
Set daemon property of executor threads

### DIFF
--- a/fluency-core/src/main/java/org/komamitsu/fluency/flusher/Flusher.java
+++ b/fluency-core/src/main/java/org/komamitsu/fluency/flusher/Flusher.java
@@ -29,7 +29,6 @@ import java.io.Closeable;
 import java.io.Flushable;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
@@ -43,7 +42,7 @@ public class Flusher
     private final AtomicBoolean isTerminated = new AtomicBoolean();
     private final Config config;
     private final BlockingQueue<Boolean> eventQueue = new LinkedBlockingQueue<>();
-    private final ExecutorService executorService = Executors.newSingleThreadExecutor();
+    private final ExecutorService executorService = ExecutorServiceUtils.newSingleThreadDaemonExecutor();
 
     public Flusher(Config config, Buffer buffer, Ingester ingester)
     {

--- a/fluency-core/src/main/java/org/komamitsu/fluency/util/ExecutorServiceUtils.java
+++ b/fluency-core/src/main/java/org/komamitsu/fluency/util/ExecutorServiceUtils.java
@@ -20,11 +20,47 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
 public class ExecutorServiceUtils
 {
     private static final Logger LOG = LoggerFactory.getLogger(ExecutorServiceUtils.class);
+
+    /**
+     * Creates an Executor that is based on daemon threads.
+     * This allows the program to quit without explicitly
+     * calling shutdown on the pool
+     *
+     * @return the newly created single-threaded Executor
+     */
+    public static ExecutorService newSingleThreadDaemonExecutor() {
+        return Executors.newSingleThreadExecutor(r -> {
+            Thread t = Executors.defaultThreadFactory().newThread(r);
+            t.setDaemon(true);
+            return t;
+        });
+    }
+
+    /**
+     * Creates a scheduled thread pool where each thread has the daemon
+     * property set to true. This allows the program to quit without
+     * explicitly calling shutdown on the pool
+     *
+     * @param corePoolSize the number of threads to keep in the pool,
+     * even if they are idle
+
+     * @return a newly created scheduled thread pool
+     */
+    public static ScheduledExecutorService newScheduledDaemonThreadPool(int corePoolSize) {
+        return Executors.newScheduledThreadPool(corePoolSize, r -> {
+            Thread t = Executors.defaultThreadFactory().newThread(r);
+            t.setDaemon(true);
+            return t;
+        });
+    }
+
 
     public static void finishExecutorService(ExecutorService executorService)
     {

--- a/fluency-fluentd/src/main/java/org/komamitsu/fluency/fluentd/ingester/sender/NetworkSender.java
+++ b/fluency-fluentd/src/main/java/org/komamitsu/fluency/fluentd/ingester/sender/NetworkSender.java
@@ -33,7 +33,6 @@ import java.util.Arrays;
 import java.util.List;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
@@ -44,7 +43,8 @@ public abstract class NetworkSender<T>
     private static final Logger LOG = LoggerFactory.getLogger(NetworkSender.class);
     private static final Charset CHARSET_FOR_ERRORLOG = Charset.forName("UTF-8");
     private final byte[] optionBuffer = new byte[256];
-    private final ExecutorService executorService = Executors.newSingleThreadExecutor();
+    private final ExecutorService executorService = ExecutorServiceUtils.newSingleThreadDaemonExecutor();
+
     private final Config config;
     private final FailureDetector failureDetector;
     private final ObjectMapper objectMapper = new ObjectMapper(new MessagePackFactory());

--- a/fluency-fluentd/src/main/java/org/komamitsu/fluency/fluentd/ingester/sender/heartbeat/Heartbeater.java
+++ b/fluency-fluentd/src/main/java/org/komamitsu/fluency/fluentd/ingester/sender/heartbeat/Heartbeater.java
@@ -40,7 +40,7 @@ public abstract class Heartbeater
     protected Heartbeater(Config config)
     {
         this.config = config;
-        executorService = Executors.newScheduledThreadPool(1);
+        executorService = ExecutorServiceUtils.newScheduledDaemonThreadPool(1);
     }
 
     public void start()


### PR DESCRIPTION
When executor threads are not set in daemons, in certain cases they prevent the program from shutting down.

Example discussion on the problem is available here: https://stackoverflow.com/questions/13883293/turning-an-executorservice-to-daemon-in-java/29453160