### PR TITLE
Adding configurability for base and max retry wait

### DIFF
--- a/fluency-fluentd/src/main/java/org/komamitsu/fluency/fluentd/FluencyBuilderForFluentd.java
+++ b/fluency-fluentd/src/main/java/org/komamitsu/fluency/fluentd/FluencyBuilderForFluentd.java
@@ -40,6 +40,8 @@ public class FluencyBuilderForFluentd
         extends org.komamitsu.fluency.FluencyBuilder
 {
     private Integer senderMaxRetryCount;
+    private Integer senderBaseRetryIntervalMillis;
+    private Integer senderMaxRetryIntervalMillis;
     private boolean ackResponseMode;
     private boolean sslEnabled;
     private Integer connectionTimeoutMilli;
@@ -48,6 +50,26 @@ public class FluencyBuilderForFluentd
     public Integer getSenderMaxRetryCount()
     {
         return senderMaxRetryCount;
+    }
+
+    public Integer getSenderBaseRetryIntervalMillis()
+    {
+        return senderBaseRetryIntervalMillis;
+    }
+
+    public Integer getSenderMaxRetryIntervalMillis()
+    {
+        return senderMaxRetryIntervalMillis;
+    }
+
+    public void setSenderBaseRetryIntervalMillis(Integer senderBaseRetryIntervalMillis)
+    {
+        this.senderBaseRetryIntervalMillis = senderBaseRetryIntervalMillis;
+    }
+
+    public void setSenderMaxRetryIntervalMillis(Integer senderMaxRetryIntervalMillis)
+    {
+        this.senderMaxRetryIntervalMillis = senderMaxRetryIntervalMillis;
     }
 
     public void setSenderMaxRetryCount(Integer senderMaxRetryCount)
@@ -212,8 +234,12 @@ public class FluencyBuilderForFluentd
             retryStrategyConfig.setMaxRetryCount(getSenderMaxRetryCount());
         }
 
-        if (getSenderMaxRetryCount() != null) {
-            retryStrategyConfig.setMaxRetryCount(getSenderMaxRetryCount());
+        if (getSenderBaseRetryIntervalMillis() != null) {
+            retryStrategyConfig.setBaseIntervalMillis(getSenderBaseRetryIntervalMillis());
+        }
+
+        if (getSenderMaxRetryIntervalMillis() != null) {
+            retryStrategyConfig.setMaxIntervalMillis(getSenderMaxRetryIntervalMillis());
         }
 
         RetryableSender.Config senderConfig = new RetryableSender.Config();

--- a/fluency-fluentd/src/test/java/org/komamitsu/fluency/fluentd/FluencyBuilderForFluentdTest.java
+++ b/fluency-fluentd/src/test/java/org/komamitsu/fluency/fluentd/FluencyBuilderForFluentdTest.java
@@ -17,7 +17,6 @@
 package org.komamitsu.fluency.fluentd;
 
 import org.junit.Test;
-import org.junit.runner.RunWith;
 import org.komamitsu.fluency.Fluency;
 import org.komamitsu.fluency.buffer.Buffer;
 import org.komamitsu.fluency.fluentd.ingester.sender.FluentdSender;
@@ -32,7 +31,6 @@ import org.komamitsu.fluency.fluentd.ingester.sender.heartbeat.SSLHeartbeater;
 import org.komamitsu.fluency.fluentd.ingester.sender.heartbeat.TCPHeartbeater;
 import org.komamitsu.fluency.fluentd.ingester.sender.retry.ExponentialBackOffRetryStrategy;
 import org.komamitsu.fluency.flusher.Flusher;
-import org.mockito.junit.MockitoJUnitRunner;
 
 import java.io.IOException;
 import java.net.InetSocketAddress;

--- a/fluency-fluentd/src/test/java/org/komamitsu/fluency/fluentd/FluencyBuilderForFluentdTest.java
+++ b/fluency-fluentd/src/test/java/org/komamitsu/fluency/fluentd/FluencyBuilderForFluentdTest.java
@@ -17,6 +17,7 @@
 package org.komamitsu.fluency.fluentd;
 
 import org.junit.Test;
+import org.junit.runner.RunWith;
 import org.komamitsu.fluency.Fluency;
 import org.komamitsu.fluency.buffer.Buffer;
 import org.komamitsu.fluency.fluentd.ingester.sender.FluentdSender;
@@ -31,6 +32,7 @@ import org.komamitsu.fluency.fluentd.ingester.sender.heartbeat.SSLHeartbeater;
 import org.komamitsu.fluency.fluentd.ingester.sender.heartbeat.TCPHeartbeater;
 import org.komamitsu.fluency.fluentd.ingester.sender.retry.ExponentialBackOffRetryStrategy;
 import org.komamitsu.fluency.flusher.Flusher;
+import org.mockito.junit.MockitoJUnitRunner;
 
 import java.io.IOException;
 import java.net.InetSocketAddress;
@@ -200,6 +202,8 @@ public class FluencyBuilderForFluentdTest
         builder.setBufferChunkRetentionTimeMillis(19 * 1000);
         builder.setJvmHeapBufferMode(true);
         builder.setSenderMaxRetryCount(99);
+        builder.setSenderBaseRetryIntervalMillis(20);
+        builder.setSenderMaxRetryIntervalMillis(100000);
         builder.setConnectionTimeoutMilli(12345);
         builder.setReadTimeoutMilli(9876);
         builder.setAckResponseMode(true);
@@ -234,7 +238,8 @@ public class FluencyBuilderForFluentdTest
             assertThat(retryableSender.getRetryStrategy(), instanceOf(ExponentialBackOffRetryStrategy.class));
             ExponentialBackOffRetryStrategy retryStrategy = (ExponentialBackOffRetryStrategy) retryableSender.getRetryStrategy();
             assertThat(retryStrategy.getMaxRetryCount(), is(99));
-            assertThat(retryStrategy.getBaseIntervalMillis(), is(400));
+            assertThat(retryStrategy.getBaseIntervalMillis(), is(20));
+            assertThat(retryStrategy.getMaxIntervalMillis(), is(100000));
 
             assertThat(retryableSender.getBaseSender(), instanceOf(MultiSender.class));
             MultiSender multiSender = (MultiSender) retryableSender.getBaseSender();
@@ -292,6 +297,8 @@ public class FluencyBuilderForFluentdTest
         builder.setBufferChunkRetentionSize(13 * 1024 * 1024);
         builder.setJvmHeapBufferMode(true);
         builder.setSenderMaxRetryCount(99);
+        builder.setSenderBaseRetryIntervalMillis(20);
+        builder.setSenderMaxRetryIntervalMillis(100000);
         builder.setConnectionTimeoutMilli(12345);
         builder.setReadTimeoutMilli(9876);
         builder.setAckResponseMode(true);
@@ -309,7 +316,8 @@ public class FluencyBuilderForFluentdTest
             assertThat(retryableSender.getRetryStrategy(), instanceOf(ExponentialBackOffRetryStrategy.class));
             ExponentialBackOffRetryStrategy retryStrategy = (ExponentialBackOffRetryStrategy) retryableSender.getRetryStrategy();
             assertThat(retryStrategy.getMaxRetryCount(), is(99));
-            assertThat(retryStrategy.getBaseIntervalMillis(), is(400));
+            assertThat(retryStrategy.getBaseIntervalMillis(), is(20));
+            assertThat(retryStrategy.getMaxIntervalMillis(), is(100000));
 
             assertThat(retryableSender.getBaseSender(), instanceOf(MultiSender.class));
             MultiSender multiSender = (MultiSender) retryableSender.getBaseSender();


### PR DESCRIPTION
Hi there

Thanks for putting together this great module. We kindly ask that you approve this pull request to add base and max retry wait configurability. Its supported already in ExponentialBackOffRetryStrategy but not exposed to external instrumentation.

Please notice that many of the tests here are using junit 4 api and are not run by default as part of gradle. I tested my own tests by adding the following line to main build.gradle dependencies:
```
testImplementation 'org.junit.vintage:junit-vintage-engine:5.3.2'
```

But I am not adding it to the pull request because there are a couple of other tests there, unrelated to my change, that are broken - see below for test output.

Thank you!

```
$ ./gradlew test

> Task :fluency-fluentd:test

org.komamitsu.fluency.buffer.BufferForFluentdTest > withFluentdFormat FAILED
    java.lang.OutOfMemoryError at BufferForFluentdTest.java:63

65 tests completed, 1 failed, 3 skipped

> Task :fluency-fluentd:test FAILED

FAILURE: Build failed with an exception.


* What went wrong:
Execution failed for task ':fluency-fluentd:test'.
> There were failing tests. See the report at: file:///home/nemo/dev/mona/client/nemo-fluency/fluency/fluency-fluentd/build/reports/tests/test/index.html

* Try:
Run with --stacktrace option to get the stack trace. Run with --info or --debug option to get more log output. Run with --scan to get full insights.

* Get more help at https://help.gradle.org

Deprecated Gradle features were used in this build, making it incompatible with Gradle 6.0.
Use '--warning-mode all' to show the individual deprecation warnings.
See https://docs.gradle.org/5.4.1/userguide/command_line_interface.html#sec:command_line_warnings

BUILD FAILED in 7m 34s
12 actionable tasks: 12 executed