### PR TITLE
Rename `flushIntervalMillis` to `flushAttemptIntervalMillis`

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ For server side configuration, see https://docs.fluentd.org/v1.0/articles/in_for
 //   - Max retry of sending events is 12
 //   - Use JVM heap memory for buffer pool
 FluencyBuilderForFluentd builder = new FluencyBuilderForFluentd();
-builder.setFlushIntervalMillis(200);
+builder.setFlushAttemptIntervalMillis(200);
 builder.setSenderMaxRetryCount(12);
 builder.setJvmHeapBufferMode(true);
 Fluency fluency = builder.build(

--- a/fluency-core/src/main/java/org/komamitsu/fluency/FluencyBuilder.java
+++ b/fluency-core/src/main/java/org/komamitsu/fluency/FluencyBuilder.java
@@ -29,7 +29,7 @@ public class FluencyBuilder
     private Integer bufferChunkInitialSize;
     private Integer bufferChunkRetentionSize;
     private Integer bufferChunkRetentionTimeMillis;
-    private Integer flushIntervalMillis;
+    private Integer flushAttemptIntervalMillis;
     private String fileBackupDir;
     private Integer waitUntilBufferFlushed;
     private Integer waitUntilFlusherTerminated;
@@ -78,14 +78,32 @@ public class FluencyBuilder
         this.bufferChunkRetentionTimeMillis = bufferChunkRetentionTimeMillis;
     }
 
+    /**
+     * @deprecated  As of release 2.3.3, replaced by {@link #getFlushAttemptIntervalMillis()}
+     */
+    @Deprecated
     public Integer getFlushIntervalMillis()
     {
-        return flushIntervalMillis;
+        return flushAttemptIntervalMillis;
     }
 
-    public void setFlushIntervalMillis(Integer flushIntervalMillis)
+    /**
+     * @deprecated  As of release 2.3.3, replaced by {@link #setFlushAttemptIntervalMillis(Integer flushAttemptIntervalMillis)}
+     */
+    @Deprecated
+    public void setFlushIntervalMillis(Integer flushAttemptIntervalMillis)
     {
-        this.flushIntervalMillis = flushIntervalMillis;
+        this.flushAttemptIntervalMillis = flushAttemptIntervalMillis;
+    }
+
+    public Integer getFlushAttemptIntervalMillis()
+    {
+        return flushAttemptIntervalMillis;
+    }
+
+    public void setFlushAttemptIntervalMillis(Integer flushAttemptIntervalMillis)
+    {
+        this.flushAttemptIntervalMillis = flushAttemptIntervalMillis;
     }
 
     public String getFileBackupDir()
@@ -146,7 +164,7 @@ public class FluencyBuilder
                 ", bufferChunkInitialSize=" + bufferChunkInitialSize +
                 ", bufferChunkRetentionSize=" + bufferChunkRetentionSize +
                 ", bufferChunkRetentionTimeMillis=" + bufferChunkRetentionTimeMillis +
-                ", flushIntervalMillis=" + flushIntervalMillis +
+                ", flushAttemptIntervalMillis=" + flushAttemptIntervalMillis +
                 ", fileBackupDir='" + fileBackupDir + '\'' +
                 ", waitUntilBufferFlushed=" + waitUntilBufferFlushed +
                 ", waitUntilFlusherTerminated=" + waitUntilFlusherTerminated +
@@ -207,8 +225,8 @@ public class FluencyBuilder
 
     protected void configureFlusherConfig(Flusher.Config flusherConfig)
     {
-        if (getFlushIntervalMillis() != null) {
-            flusherConfig.setFlushIntervalMillis(getFlushIntervalMillis());
+        if (getFlushAttemptIntervalMillis() != null) {
+            flusherConfig.setFlushAttemptIntervalMillis(getFlushAttemptIntervalMillis());
         }
 
         if (getWaitUntilBufferFlushed() != null) {

--- a/fluency-core/src/main/java/org/komamitsu/fluency/flusher/Flusher.java
+++ b/fluency-core/src/main/java/org/komamitsu/fluency/flusher/Flusher.java
@@ -61,7 +61,7 @@ public class Flusher
         Boolean wakeup = null;
         do {
             try {
-                wakeup = eventQueue.poll(config.getFlushIntervalMillis(), TimeUnit.MILLISECONDS);
+                wakeup = eventQueue.poll(config.getFlushAttemptIntervalMillis(), TimeUnit.MILLISECONDS);
                 boolean force = wakeup != null;
                 buffer.flush(ingester, force);
             }
@@ -199,9 +199,18 @@ public class Flusher
         return ingester;
     }
 
+    /**
+     * @deprecated  As of release 2.3.3, replaced by {@link #getFlushAttemptIntervalMillis()}
+     */
+    @Deprecated
     public int getFlushIntervalMillis()
     {
-        return config.getFlushIntervalMillis();
+        return config.getFlushAttemptIntervalMillis();
+    }
+
+    public int getFlushAttemptIntervalMillis()
+    {
+        return config.getFlushAttemptIntervalMillis();
     }
 
     public int getWaitUntilBufferFlushed()
@@ -230,20 +239,38 @@ public class Flusher
     {
         @Min(20)
         @Max(2000)
-        private int flushIntervalMillis = 600;
+        private int flushAttemptIntervalMillis = 600;
         @Min(1)
         private int waitUntilBufferFlushed = 60;
         @Min(1)
         private int waitUntilTerminated = 60;
 
+        /**
+         * @deprecated  As of release 2.3.3, replaced by {@link #getFlushAttemptIntervalMillis()}
+         */
+        @Deprecated
         public int getFlushIntervalMillis()
         {
-            return flushIntervalMillis;
+            return flushAttemptIntervalMillis;
         }
 
-        public void setFlushIntervalMillis(int flushIntervalMillis)
+        /**
+         * @deprecated  As of release 2.3.3, replaced by {@link #setFlushAttemptIntervalMillis(int flushAttemptIntervalMillis)}
+         */
+        @Deprecated
+        public void setFlushIntervalMillis(int flushAttemptIntervalMillis)
         {
-            this.flushIntervalMillis = flushIntervalMillis;
+            this.flushAttemptIntervalMillis = flushAttemptIntervalMillis;
+        }
+
+        public int getFlushAttemptIntervalMillis()
+        {
+            return flushAttemptIntervalMillis;
+        }
+
+        public void setFlushAttemptIntervalMillis(int flushAttemptIntervalMillis)
+        {
+            this.flushAttemptIntervalMillis = flushAttemptIntervalMillis;
         }
 
         public int getWaitUntilBufferFlushed()
@@ -275,7 +302,7 @@ public class Flusher
         public String toString()
         {
             return "Config{" +
-                    "flushIntervalMillis=" + flushIntervalMillis +
+                    "flushAttemptIntervalMillis=" + flushAttemptIntervalMillis +
                     ", waitUntilBufferFlushed=" + waitUntilBufferFlushed +
                     ", waitUntilTerminated=" + waitUntilTerminated +
                     '}';

--- a/fluency-core/src/test/java/org/komamitsu/fluency/FluencyTest.java
+++ b/fluency-core/src/test/java/org/komamitsu/fluency/FluencyTest.java
@@ -130,7 +130,7 @@ class FluencyTest
     void testWaitUntilFlushingAllBuffer(int waitUntilFlusherTerm, boolean expected)
             throws IOException, InterruptedException
     {
-        flusherConfig.setFlushIntervalMillis(2000);
+        flusherConfig.setFlushAttemptIntervalMillis(2000);
 
         Buffer buffer = new Buffer(bufferConfig, new JsonRecordFormatter());
         Flusher flusher = new Flusher(flusherConfig, buffer, ingester);
@@ -151,7 +151,7 @@ class FluencyTest
         bufferConfig.setChunkExpandRatio(2);
         bufferConfig.setMaxBufferSize(256);
         bufferConfig.setChunkRetentionSize(196);
-        flusherConfig.setFlushIntervalMillis(1000);
+        flusherConfig.setFlushAttemptIntervalMillis(1000);
 
         Buffer buffer = new Buffer(bufferConfig, new JsonRecordFormatter());
         Flusher flusher = new Flusher(flusherConfig, buffer, stuckIngester);

--- a/fluency-core/src/test/java/org/komamitsu/fluency/flusher/FlusherTest.java
+++ b/fluency-core/src/test/java/org/komamitsu/fluency/flusher/FlusherTest.java
@@ -54,7 +54,7 @@ class FlusherTest
     void testAsyncFlusher()
             throws IOException, InterruptedException
     {
-        flusherConfig.setFlushIntervalMillis(500);
+        flusherConfig.setFlushAttemptIntervalMillis(500);
 
         Buffer buffer = spy(new Buffer(bufferConfig, new JsonRecordFormatter()));
         Flusher flusher = new Flusher(flusherConfig, buffer, ingester);
@@ -92,13 +92,13 @@ class FlusherTest
 
         {
             Flusher.Config config = new Flusher.Config();
-            config.setFlushIntervalMillis(19);
+            config.setFlushAttemptIntervalMillis(19);
             assertThrows(IllegalArgumentException.class, () -> new Flusher(config, buffer, ingester));
         }
 
         {
             Flusher.Config config = new Flusher.Config();
-            config.setFlushIntervalMillis(2001);
+            config.setFlushAttemptIntervalMillis(2001);
             assertThrows(IllegalArgumentException.class, () -> new Flusher(config, buffer, ingester));
         }
 

--- a/fluency-fluentd/src/test/java/org/komamitsu/fluency/fluentd/FluencyBuilderForFluentdTest.java
+++ b/fluency-fluentd/src/test/java/org/komamitsu/fluency/fluentd/FluencyBuilderForFluentdTest.java
@@ -59,7 +59,7 @@ class FluencyBuilderForFluentdTest
     private void assertFlusher(Flusher flusher)
     {
         assertThat(flusher.isTerminated(), is(false));
-        assertThat(flusher.getFlushIntervalMillis(), is(600));
+        assertThat(flusher.getFlushAttemptIntervalMillis(), is(600));
         assertThat(flusher.getWaitUntilBufferFlushed(), is(60));
         assertThat(flusher.getWaitUntilTerminated(), is(60));
     }
@@ -193,7 +193,7 @@ class FluencyBuilderForFluentdTest
         assertThat(tmpdir, is(notNullValue()));
 
         FluencyBuilderForFluentd builder = new FluencyBuilderForFluentd();
-        builder.setFlushIntervalMillis(200);
+        builder.setFlushAttemptIntervalMillis(200);
         builder.setMaxBufferSize(Long.MAX_VALUE);
         builder.setBufferChunkInitialSize(7 * 1024 * 1024);
         builder.setBufferChunkRetentionSize(13 * 1024 * 1024);
@@ -227,7 +227,7 @@ class FluencyBuilderForFluentdTest
 
             Flusher flusher = fluency.getFlusher();
             assertThat(flusher.isTerminated(), is(false));
-            assertThat(flusher.getFlushIntervalMillis(), is(200));
+            assertThat(flusher.getFlushAttemptIntervalMillis(), is(200));
             assertThat(flusher.getWaitUntilBufferFlushed(), is(42));
             assertThat(flusher.getWaitUntilTerminated(), is(24));
 
@@ -289,7 +289,7 @@ class FluencyBuilderForFluentdTest
 
         FluencyBuilderForFluentd builder = new FluencyBuilderForFluentd();
         builder.setSslEnabled(true);
-        builder.setFlushIntervalMillis(200);
+        builder.setFlushAttemptIntervalMillis(200);
         builder.setMaxBufferSize(Long.MAX_VALUE);
         builder.setBufferChunkInitialSize(7 * 1024 * 1024);
         builder.setBufferChunkRetentionSize(13 * 1024 * 1024);

--- a/fluency-treasuredata/src/test/java/org/komamitsu/fluency/treasuredata/FluencyBuilderForTreasureDataTest.java
+++ b/fluency-treasuredata/src/test/java/org/komamitsu/fluency/treasuredata/FluencyBuilderForTreasureDataTest.java
@@ -53,7 +53,7 @@ public class FluencyBuilderForTreasureDataTest
     private void assertFlusher(Flusher flusher)
     {
         assertThat(flusher.isTerminated(), is(false));
-        assertThat(flusher.getFlushIntervalMillis(), is(600));
+        assertThat(flusher.getFlushAttemptIntervalMillis(), is(600));
         assertThat(flusher.getWaitUntilBufferFlushed(), is(60));
         assertThat(flusher.getWaitUntilTerminated(), is(60));
     }
@@ -144,7 +144,7 @@ public class FluencyBuilderForTreasureDataTest
         assertThat(tmpdir, is(notNullValue()));
 
         FluencyBuilderForTreasureData builder = new FluencyBuilderForTreasureData();
-        builder.setFlushIntervalMillis(200);
+        builder.setFlushAttemptIntervalMillis(200);
         builder.setMaxBufferSize(Long.MAX_VALUE);
         builder.setBufferChunkInitialSize(7 * 1024 * 1024);
         builder.setBufferChunkRetentionSize(13 * 1024 * 1024);
@@ -174,7 +174,7 @@ public class FluencyBuilderForTreasureDataTest
 
             Flusher flusher = fluency.getFlusher();
             assertThat(flusher.isTerminated(), is(false));
-            assertThat(flusher.getFlushIntervalMillis(), is(200));
+            assertThat(flusher.getFlushAttemptIntervalMillis(), is(200));
             assertThat(flusher.getWaitUntilBufferFlushed(), is(42));
             assertThat(flusher.getWaitUntilTerminated(), is(24));
 


### PR DESCRIPTION
Flusher had `flushIntervalMillis`. But the name was a bit far from actual behavior because Flusher just tries to flush at the interval and whether a buffer is flushed depends on the buffered duration or size reaches a threshold.