### PR TITLE
Restricting the size of eventQueue

### DIFF
--- a/fluency-core/src/main/java/org/komamitsu/fluency/flusher/Flusher.java
+++ b/fluency-core/src/main/java/org/komamitsu/fluency/flusher/Flusher.java
@@ -41,7 +41,7 @@ public class Flusher
         implements Flushable, Closeable
 {
     private static final Logger LOG = LoggerFactory.getLogger(Flusher.class);
-    private static final int DEFAULT_EVENT_QUEUE_SIZE = 256;
+    private static final int DEFAULT_EVENT_QUEUE_SIZE = 16;
     protected final Buffer buffer;
     protected final Ingester ingester;
     private final AtomicBoolean isTerminated = new AtomicBoolean();
@@ -79,7 +79,7 @@ public class Flusher
             // The above run loop can quit without force buffer flush in the following cases
             // - close() is called right after the repeated non-force buffer flush executed in the run loop
             //
-            // In these cases, remaining buffers wont't be flushed.
+            // In these cases, remaining buffers won't be flushed.
             // So force buffer flush is executed here just in case
             try {
                 buffer.flush(ingester, true);

--- a/fluency-core/src/main/java/org/komamitsu/fluency/flusher/Flusher.java
+++ b/fluency-core/src/main/java/org/komamitsu/fluency/flusher/Flusher.java
@@ -41,11 +41,12 @@ public class Flusher
         implements Flushable, Closeable
 {
     private static final Logger LOG = LoggerFactory.getLogger(Flusher.class);
+    private static final int DEFAULT_EVENT_QUEUE_SIZE = 256;
     protected final Buffer buffer;
     protected final Ingester ingester;
     private final AtomicBoolean isTerminated = new AtomicBoolean();
     private final Config config;
-    private final BlockingQueue<Boolean> eventQueue = new LinkedBlockingQueue<>();
+    private final BlockingQueue<Boolean> eventQueue = new LinkedBlockingQueue<>(DEFAULT_EVENT_QUEUE_SIZE);
     private final ExecutorService executorService = ExecutorServiceUtils.newSingleThreadDaemonExecutor();
 
     public Flusher(Config config, Buffer buffer, Ingester ingester)
@@ -97,13 +98,7 @@ public class Flusher
     @Override
     public void flush()
     {
-        try {
-            eventQueue.put(true);
-        }
-        catch (InterruptedException e) {
-            LOG.warn("Failed to force flushing buffer", e);
-            Thread.currentThread().interrupt();
-        }
+        eventQueue.offer(true);
     }
 
     private void flushBufferQuietly()


### PR DESCRIPTION
In some cases Emitter.emit() keeps throwing BufferFullException, this queue becomes extremely large and eventually causes an OOM