### PR TITLE
Add SSLSocketFactory override to builder

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,7 @@ jobs:
     - name: Run tests using real Fluentd
       run: |
         ./gradlew publishToMavenLocal --stacktrace --info
+        sudo gem install yajl-ruby -v 1.4.1
         sudo gem install fluentd --no-doc
         echo "127.0.0.1 my-server" | sudo tee -a /etc/hosts
         cd tests/mutual-tls && ./run.sh

--- a/README.md
+++ b/README.md
@@ -185,6 +185,10 @@ fluency.emit("foo.bar", event);
 //   - Enable SSL/TLS
 FluencyBuilderForFluentd builder = new FluencyBuilderForFluentd();
 builder.setSslEnabled(true);
+
+// Or, provide your own SSLSocketFactory at runtime (replace with your own)
+builder.setSslSocketFactory(SSLSocketFactory.getDefault())
+
 Fluency fluency = builder.build();
 ```
 

--- a/fluency-fluentd/src/main/java/org/komamitsu/fluency/fluentd/FluencyBuilderForFluentd.java
+++ b/fluency-fluentd/src/main/java/org/komamitsu/fluency/fluentd/FluencyBuilderForFluentd.java
@@ -32,7 +32,6 @@ import org.komamitsu.fluency.fluentd.recordformat.FluentdRecordFormatter;
 import org.komamitsu.fluency.ingester.Ingester;
 
 import java.net.InetSocketAddress;
-import javax.net.SocketFactory;
 import javax.net.ssl.SSLSocketFactory;
 import java.util.ArrayList;
 import java.util.List;

--- a/fluency-fluentd/src/main/java/org/komamitsu/fluency/fluentd/FluencyBuilderForFluentd.java
+++ b/fluency-fluentd/src/main/java/org/komamitsu/fluency/fluentd/FluencyBuilderForFluentd.java
@@ -33,6 +33,7 @@ import org.komamitsu.fluency.ingester.Ingester;
 
 import java.net.InetSocketAddress;
 import javax.net.SocketFactory;
+import javax.net.ssl.SSLSocketFactory;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -44,7 +45,7 @@ public class FluencyBuilderForFluentd
     private Integer senderMaxRetryIntervalMillis;
     private boolean ackResponseMode;
     private boolean sslEnabled;
-    private SocketFactory sslSocketFactory;
+    private SSLSocketFactory sslSocketFactory;
     private Integer connectionTimeoutMilli;
     private Integer readTimeoutMilli;
     private FluentdRecordFormatter recordFormatter = new FluentdRecordFormatter();
@@ -99,7 +100,7 @@ public class FluencyBuilderForFluentd
         this.sslEnabled = sslEnabled;
     }
 
-    public void setSslSocketFactory(SocketFactory sslSocketFactory) {
+    public void setSslSocketFactory(SSLSocketFactory sslSocketFactory) {
         this.sslSocketFactory = sslSocketFactory;
     }
 

--- a/fluency-fluentd/src/main/java/org/komamitsu/fluency/fluentd/FluencyBuilderForFluentd.java
+++ b/fluency-fluentd/src/main/java/org/komamitsu/fluency/fluentd/FluencyBuilderForFluentd.java
@@ -32,6 +32,7 @@ import org.komamitsu.fluency.fluentd.recordformat.FluentdRecordFormatter;
 import org.komamitsu.fluency.ingester.Ingester;
 
 import java.net.InetSocketAddress;
+import javax.net.SocketFactory;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -43,6 +44,7 @@ public class FluencyBuilderForFluentd
     private Integer senderMaxRetryIntervalMillis;
     private boolean ackResponseMode;
     private boolean sslEnabled;
+    private SocketFactory sslSocketFactory;
     private Integer connectionTimeoutMilli;
     private Integer readTimeoutMilli;
     private FluentdRecordFormatter recordFormatter = new FluentdRecordFormatter();
@@ -95,6 +97,10 @@ public class FluencyBuilderForFluentd
     public void setSslEnabled(boolean sslEnabled)
     {
         this.sslEnabled = sslEnabled;
+    }
+
+    public void setSslSocketFactory(SocketFactory sslSocketFactory) {
+        this.sslSocketFactory = sslSocketFactory;
     }
 
     public Integer getConnectionTimeoutMilli()
@@ -179,10 +185,18 @@ public class FluencyBuilderForFluentd
             if (port != null) {
                 senderConfig.setPort(port);
             }
+            if (sslSocketFactory != null) {
+                senderConfig.setSslSocketFactory(sslSocketFactory);
+            }
             if (withHeartBeater) {
                 SSLHeartbeater.Config hbConfig = new SSLHeartbeater.Config();
                 hbConfig.setHost(host);
                 hbConfig.setPort(port);
+
+                if (sslSocketFactory != null) {
+                    hbConfig.setSslSocketFactory(sslSocketFactory);
+                }
+
                 SSLHeartbeater heartbeater = new SSLHeartbeater(hbConfig);
                 failureDetector = new FailureDetector(new PhiAccrualFailureDetectStrategy(), heartbeater);
             }

--- a/fluency-fluentd/src/main/java/org/komamitsu/fluency/fluentd/FluencyBuilderForFluentd.java
+++ b/fluency-fluentd/src/main/java/org/komamitsu/fluency/fluentd/FluencyBuilderForFluentd.java
@@ -99,7 +99,8 @@ public class FluencyBuilderForFluentd
         this.sslEnabled = sslEnabled;
     }
 
-    public void setSslSocketFactory(SSLSocketFactory sslSocketFactory) {
+    public void setSslSocketFactory(SSLSocketFactory sslSocketFactory)
+    {
         this.sslSocketFactory = sslSocketFactory;
     }
 

--- a/fluency-fluentd/src/main/java/org/komamitsu/fluency/fluentd/ingester/sender/NetworkSender.java
+++ b/fluency-fluentd/src/main/java/org/komamitsu/fluency/fluentd/ingester/sender/NetworkSender.java
@@ -34,7 +34,6 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
-import javax.net.ssl.SSLSocketFactory;
 
 public abstract class NetworkSender<T>
         extends FluentdSender

--- a/fluency-fluentd/src/main/java/org/komamitsu/fluency/fluentd/ingester/sender/NetworkSender.java
+++ b/fluency-fluentd/src/main/java/org/komamitsu/fluency/fluentd/ingester/sender/NetworkSender.java
@@ -34,6 +34,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import javax.net.ssl.SSLSocketFactory;
 
 public abstract class NetworkSender<T>
         extends FluentdSender

--- a/fluency-fluentd/src/main/java/org/komamitsu/fluency/fluentd/ingester/sender/SSLSender.java
+++ b/fluency-fluentd/src/main/java/org/komamitsu/fluency/fluentd/ingester/sender/SSLSender.java
@@ -21,7 +21,6 @@ import org.komamitsu.fluency.validation.Validatable;
 
 import javax.net.ssl.SSLSocket;
 import javax.net.ssl.SSLSocketFactory;
-import javax.net.SocketFactory;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -132,11 +131,13 @@ public class SSLSender
 
         private SSLSocketFactory sslSocketFactory = (SSLSocketFactory) SSLSocketFactory.getDefault();
 
-        public SSLSocketFactory getSslSocketFactory() {
+        public SSLSocketFactory getSslSocketFactory()
+        {
             return sslSocketFactory;
         }
 
-        public void setSslSocketFactory(SSLSocketFactory sslSocketFactory) {
+        public void setSslSocketFactory(SSLSocketFactory sslSocketFactory)
+        {
             this.sslSocketFactory = sslSocketFactory;
         }
     }

--- a/fluency-fluentd/src/main/java/org/komamitsu/fluency/fluentd/ingester/sender/SSLSender.java
+++ b/fluency-fluentd/src/main/java/org/komamitsu/fluency/fluentd/ingester/sender/SSLSender.java
@@ -20,6 +20,7 @@ import org.komamitsu.fluency.fluentd.ingester.sender.failuredetect.FailureDetect
 import org.komamitsu.fluency.validation.Validatable;
 
 import javax.net.ssl.SSLSocket;
+import javax.net.SocketFactory;
 
 import java.io.IOException;
 import java.io.InputStream;
@@ -54,11 +55,13 @@ public class SSLSender
     {
         super(config, failureDetector);
         config.validateValues();
+
         socketBuilder = new SSLSocketBuilder(
                 config.getHost(),
                 config.getPort(),
                 config.getConnectionTimeoutMilli(),
-                config.getReadTimeoutMilli());
+                config.getReadTimeoutMilli(),
+                config.getSslSocketFactory());
         this.config = config;
     }
 
@@ -124,6 +127,16 @@ public class SSLSender
         void validateValues()
         {
             validate();
+        }
+
+        private SocketFactory sslSocketFactory = SocketFactory.getDefault();
+
+        public SocketFactory getSslSocketFactory() {
+            return sslSocketFactory;
+        }
+
+        public void setSslSocketFactory(SocketFactory sslSocketFactory) {
+            this.sslSocketFactory = sslSocketFactory;
         }
     }
 }

--- a/fluency-fluentd/src/main/java/org/komamitsu/fluency/fluentd/ingester/sender/SSLSender.java
+++ b/fluency-fluentd/src/main/java/org/komamitsu/fluency/fluentd/ingester/sender/SSLSender.java
@@ -20,6 +20,7 @@ import org.komamitsu.fluency.fluentd.ingester.sender.failuredetect.FailureDetect
 import org.komamitsu.fluency.validation.Validatable;
 
 import javax.net.ssl.SSLSocket;
+import javax.net.ssl.SSLSocketFactory;
 import javax.net.SocketFactory;
 
 import java.io.IOException;
@@ -129,13 +130,13 @@ public class SSLSender
             validate();
         }
 
-        private SocketFactory sslSocketFactory = SocketFactory.getDefault();
+        private SSLSocketFactory sslSocketFactory = (SSLSocketFactory) SSLSocketFactory.getDefault();
 
-        public SocketFactory getSslSocketFactory() {
+        public SSLSocketFactory getSslSocketFactory() {
             return sslSocketFactory;
         }
 
-        public void setSslSocketFactory(SocketFactory sslSocketFactory) {
+        public void setSslSocketFactory(SSLSocketFactory sslSocketFactory) {
             this.sslSocketFactory = sslSocketFactory;
         }
     }

--- a/fluency-fluentd/src/main/java/org/komamitsu/fluency/fluentd/ingester/sender/SSLSocketBuilder.java
+++ b/fluency-fluentd/src/main/java/org/komamitsu/fluency/fluentd/ingester/sender/SSLSocketBuilder.java
@@ -17,6 +17,7 @@
 package org.komamitsu.fluency.fluentd.ingester.sender;
 
 import javax.net.ssl.SSLSocket;
+import javax.net.ssl.SSLSocketFactory;
 import javax.net.SocketFactory;
 
 import java.io.IOException;
@@ -31,7 +32,7 @@ public class SSLSocketBuilder
     private final int readTimeoutMilli;
     private final SocketFactory sslSocketFactory;
 
-    public SSLSocketBuilder(String host, Integer port, int connectionTimeoutMilli, int readTimeoutMilli, SocketFactory sslSocketFactory)
+    public SSLSocketBuilder(String host, Integer port, int connectionTimeoutMilli, int readTimeoutMilli, SSLSocketFactory sslSocketFactory)
     {
         this.host = host;
         this.port = port;

--- a/fluency-fluentd/src/main/java/org/komamitsu/fluency/fluentd/ingester/sender/SSLSocketBuilder.java
+++ b/fluency-fluentd/src/main/java/org/komamitsu/fluency/fluentd/ingester/sender/SSLSocketBuilder.java
@@ -17,7 +17,7 @@
 package org.komamitsu.fluency.fluentd.ingester.sender;
 
 import javax.net.ssl.SSLSocket;
-import javax.net.ssl.SSLSocketFactory;
+import javax.net.SocketFactory;
 
 import java.io.IOException;
 import java.net.InetSocketAddress;
@@ -29,19 +29,21 @@ public class SSLSocketBuilder
     private final int port;
     private final int connectionTimeoutMilli;
     private final int readTimeoutMilli;
+    private final SocketFactory sslSocketFactory;
 
-    public SSLSocketBuilder(String host, Integer port, int connectionTimeoutMilli, int readTimeoutMilli)
+    public SSLSocketBuilder(String host, Integer port, int connectionTimeoutMilli, int readTimeoutMilli, SocketFactory sslSocketFactory)
     {
         this.host = host;
         this.port = port;
         this.connectionTimeoutMilli = connectionTimeoutMilli;
         this.readTimeoutMilli = readTimeoutMilli;
+        this.sslSocketFactory = sslSocketFactory;
     }
 
     public SSLSocket build()
             throws IOException
     {
-        Socket socket = SSLSocketFactory.getDefault().createSocket();
+        Socket socket = this.sslSocketFactory.createSocket();
         try {
             socket.connect(new InetSocketAddress(host, port), connectionTimeoutMilli);
             socket.setTcpNoDelay(true);

--- a/fluency-fluentd/src/main/java/org/komamitsu/fluency/fluentd/ingester/sender/SSLSocketBuilder.java
+++ b/fluency-fluentd/src/main/java/org/komamitsu/fluency/fluentd/ingester/sender/SSLSocketBuilder.java
@@ -30,15 +30,15 @@ public class SSLSocketBuilder
     private final int port;
     private final int connectionTimeoutMilli;
     private final int readTimeoutMilli;
-    private final SocketFactory sslSocketFactory;
+    private final SSLSocketFactory sslSocketFactory;
 
-    public SSLSocketBuilder(String host, Integer port, int connectionTimeoutMilli, int readTimeoutMilli, SSLSocketFactory sslSocketFactory)
+    public SSLSocketBuilder(String host, Integer port, int connectionTimeoutMilli, int readTimeoutMilli, SocketFactory sslSocketFactory)
     {
         this.host = host;
         this.port = port;
         this.connectionTimeoutMilli = connectionTimeoutMilli;
         this.readTimeoutMilli = readTimeoutMilli;
-        this.sslSocketFactory = sslSocketFactory;
+        this.sslSocketFactory = (SSLSocketFactory)sslSocketFactory;
     }
 
     public SSLSocket build()

--- a/fluency-fluentd/src/main/java/org/komamitsu/fluency/fluentd/ingester/sender/heartbeat/SSLHeartbeater.java
+++ b/fluency-fluentd/src/main/java/org/komamitsu/fluency/fluentd/ingester/sender/heartbeat/SSLHeartbeater.java
@@ -23,6 +23,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import javax.net.ssl.SSLSocket;
+import javax.net.ssl.SSLSocketFactory;
+import javax.net.SocketFactory;
 
 import java.io.IOException;
 
@@ -44,10 +46,12 @@ public class SSLHeartbeater
         config.validateValues();
         this.config = config;
         sslSocketBuilder = new SSLSocketBuilder(
-                config.getHost(),
-                config.getPort(),
-                config.connectionTimeoutMilli,
-                config.readTimeoutMilli);
+            config.getHost(),
+            config.getPort(),
+            config.connectionTimeoutMilli,
+            config.readTimeoutMilli,
+            config.getSslSocketFactory()
+        );
     }
 
     @Override
@@ -98,6 +102,16 @@ public class SSLHeartbeater
         public void setReadTimeoutMilli(int readTimeoutMilli)
         {
             this.readTimeoutMilli = readTimeoutMilli;
+        }
+
+        private SocketFactory sslSocketFactory = SSLSocketFactory.getDefault();
+
+        public SocketFactory getSslSocketFactory() {
+            return sslSocketFactory;
+        }
+
+        public void setSslSocketFactory(SocketFactory sslSocketFactory) {
+            this.sslSocketFactory = sslSocketFactory;
         }
 
         void validateValues()

--- a/fluency-fluentd/src/main/java/org/komamitsu/fluency/fluentd/ingester/sender/heartbeat/SSLHeartbeater.java
+++ b/fluency-fluentd/src/main/java/org/komamitsu/fluency/fluentd/ingester/sender/heartbeat/SSLHeartbeater.java
@@ -104,13 +104,13 @@ public class SSLHeartbeater
             this.readTimeoutMilli = readTimeoutMilli;
         }
 
-        private SocketFactory sslSocketFactory = SSLSocketFactory.getDefault();
+        private SSLSocketFactory sslSocketFactory = (SSLSocketFactory) SSLSocketFactory.getDefault();
 
-        public SocketFactory getSslSocketFactory() {
+        public SSLSocketFactory getSslSocketFactory() {
             return sslSocketFactory;
         }
 
-        public void setSslSocketFactory(SocketFactory sslSocketFactory) {
+        public void setSslSocketFactory(SSLSocketFactory sslSocketFactory) {
             this.sslSocketFactory = sslSocketFactory;
         }
 

--- a/fluency-fluentd/src/main/java/org/komamitsu/fluency/fluentd/ingester/sender/heartbeat/SSLHeartbeater.java
+++ b/fluency-fluentd/src/main/java/org/komamitsu/fluency/fluentd/ingester/sender/heartbeat/SSLHeartbeater.java
@@ -24,7 +24,6 @@ import org.slf4j.LoggerFactory;
 
 import javax.net.ssl.SSLSocket;
 import javax.net.ssl.SSLSocketFactory;
-import javax.net.SocketFactory;
 
 import java.io.IOException;
 
@@ -106,11 +105,13 @@ public class SSLHeartbeater
 
         private SSLSocketFactory sslSocketFactory = (SSLSocketFactory) SSLSocketFactory.getDefault();
 
-        public SSLSocketFactory getSslSocketFactory() {
+        public SSLSocketFactory getSslSocketFactory()
+        {
             return sslSocketFactory;
         }
 
-        public void setSslSocketFactory(SSLSocketFactory sslSocketFactory) {
+        public void setSslSocketFactory(SSLSocketFactory sslSocketFactory)
+        {
             this.sslSocketFactory = sslSocketFactory;
         }
 

--- a/fluency-fluentd/src/test/java/org/komamitsu/fluency/fluentd/ingester/sender/SSLSocketBuilderTest.java
+++ b/fluency-fluentd/src/test/java/org/komamitsu/fluency/fluentd/ingester/sender/SSLSocketBuilderTest.java
@@ -22,6 +22,7 @@ import org.junit.jupiter.api.Test;
 
 import javax.net.ssl.SSLServerSocket;
 import javax.net.ssl.SSLSocket;
+import javax.net.ssl.SSLSocketFactory;
 
 import java.io.IOException;
 import java.io.OutputStream;
@@ -82,7 +83,7 @@ class SSLSocketBuilderTest
             }
         });
 
-        SSLSocket sslSocket = new SSLSocketBuilder("localhost", serverSocket.getLocalPort(), 5000, 5000).build();
+        SSLSocket sslSocket = new SSLSocketBuilder("localhost", serverSocket.getLocalPort(), 5000, 5000, (SSLSocketFactory) SSLSocketFactory.getDefault()).build();
 
         try {
             OutputStream outputStream = sslSocket.getOutputStream();

--- a/fluency-fluentd/src/test/java/org/komamitsu/fluency/fluentd/ingester/sender/SSLSocketBuilderTest.java
+++ b/fluency-fluentd/src/test/java/org/komamitsu/fluency/fluentd/ingester/sender/SSLSocketBuilderTest.java
@@ -83,7 +83,7 @@ class SSLSocketBuilderTest
             }
         });
 
-        SSLSocket sslSocket = new SSLSocketBuilder("localhost", serverSocket.getLocalPort(), 5000, 5000, (SSLSocketFactory) SSLSocketFactory.getDefault()).build();
+        SSLSocket sslSocket = new SSLSocketBuilder("localhost", serverSocket.getLocalPort(), 5000, 5000, SSLSocketFactory.getDefault()).build();
 
         try {
             OutputStream outputStream = sslSocket.getOutputStream();


### PR DESCRIPTION
Hi!

Thank you for this awesome library! This change exposes a new builder method to allow users to change the `SSLSocketFactory` implementation used, giving users the ability to configure trust settings at runtime. We cannot set our `JAVA_OPTS` in Databricks' Apache Spark environment, so this is the only way we can pipe logs to our fluentd sink (unless, this change is unnecessary and we had overlooked something).

Let me know if there are any addl. changes or tests needed!

---

Our usage in Scala looks like this, along with [sslcontext-kickstart](https://github.com/Hakky54/sslcontext-kickstart)

```scala
val cert = 
"""
-----BEGIN CERTIFICATE-----
-----END CERTIFICATE-----
"""

val key = 
"""
-----BEGIN RSA PRIVATE KEY-----
-----END RSA PRIVATE KEY-----
"""

val keyManager = PemUtils.parseIdentityMaterial(cert, key, "shhh".toCharArray);
val sslBuilder = SSLFactory.builder.withIdentityMaterial(keyManager).build()

val builder = new FluencyBuilderForFluentd()
builder.setSslEnabled(true)
builder.setWaitUntilBufferFlushed(5000)
builder.setWaitUntilFlusherTerminated(5000)
builder.setSenderMaxRetryCount(4)
builder.setSslSocketFactory(sslBuilder.getSslSocketFactory)

val fluency = builder.build("my-url.com", 24224)
fluency.emit(
  "cats-report", 
  Map("hopper" -> "napping", "lala" -> "napping", "linus" -> "hungry").asInstanceOf[Map[String, Object]].asJava
)
fluency.close()
```