### PR TITLE
Fix potential data loss

### DIFF
--- a/fluency-core/src/main/java/org/komamitsu/fluency/buffer/Buffer.java
+++ b/fluency-core/src/main/java/org/komamitsu/fluency/buffer/Buffer.java
@@ -189,8 +189,9 @@ public class Buffer
 
         RetentionBuffer newBuffer = new RetentionBuffer(acquiredBuffer, System.currentTimeMillis());
         if (retentionBuffer != null) {
-            retentionBuffer.getByteBuffer().flip();
-            newBuffer.getByteBuffer().put(retentionBuffer.getByteBuffer());
+            ByteBuffer buf = retentionBuffer.getByteBuffer().duplicate();
+            buf.flip();
+            newBuffer.getByteBuffer().put(buf);
             bufferPool.returnBuffer(retentionBuffer.getByteBuffer());
         }
         LOG.trace("prepareBuffer(): allocate a new buffer. tag={}, buffer={}", tag, newBuffer);
@@ -334,8 +335,9 @@ public class Buffer
     {
         try {
             LOG.trace("moveRetentionBufferToFlushable(): tag={}, buffer={}", tag, buffer);
-            buffer.getByteBuffer().flip();
-            flushableBuffers.put(new TaggableBuffer(tag, buffer.getByteBuffer()));
+            ByteBuffer buf = buffer.getByteBuffer().duplicate();
+            buf.flip();
+            flushableBuffers.put(new TaggableBuffer(tag, buf));
             retentionBuffers.put(tag, null);
         }
         catch (InterruptedException e) {


### PR DESCRIPTION
Fixes https://github.com/komamitsu/fluency/issues/743

The issue happens when the application executes the following steps:
- catch an interruption
- call `Thread.currentThread.interrupt()`
- continue the processing not stopping the application

So, I think the possibility the issue occurs is quite low. But the error handling of Fluency should be fixed as the reporter said.

This PR fixed the potential data loss issue.