### PR TITLE
 Support hyphens(`-`) in backup file name patterns

### DIFF
--- a/fluency-core/src/main/java/org/komamitsu/fluency/buffer/FileBackup.java
+++ b/fluency-core/src/main/java/org/komamitsu/fluency/buffer/FileBackup.java
@@ -54,7 +54,7 @@ public class FileBackup
         this.backupDir = backupDir;
         this.userBuffer = userBuffer;
         this.prefix = prefix;
-        this.pattern = Pattern.compile(userBuffer.bufferFormatType() + prefix() + PARAM_DELIM_IN_FILENAME + "([\\w\\." + PARAM_DELIM_IN_FILENAME + "]+)" + EXT_FILENAME);
+        this.pattern = Pattern.compile(userBuffer.bufferFormatType() + prefix() + PARAM_DELIM_IN_FILENAME + "([\\w\\.\\-" + PARAM_DELIM_IN_FILENAME + "]+)" + EXT_FILENAME);
         LOG.debug(this.toString());
     }
 


### PR DESCRIPTION
Currently, backups with hyphens in the file name are not restored due to pattern mismatch.The buckup file name contains a fluentd tag name, so if the tag has hyphens, it cannot be restored.
I want to use a fluentd tag contains hyphens, so I would like to fix this issue.