### PR TITLE
Update Maven Central badge in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Fluency
-[![Maven Central](https://maven-badges.herokuapp.com/maven-central/org.komamitsu/fluency-core/badge.svg)](https://maven-badges.herokuapp.com/maven-central/org.komamitsu/fluency-core)
+[![Maven Central](https://img.shields.io/maven-central/v/org.komamitsu/fluency-core.svg)](https://search.maven.org/artifact/org.komamitsu/fluency-core)
 [<img src="https://travis-ci.org/komamitsu/fluency.svg?branch=master"/>](https://travis-ci.org/komamitsu/fluency) [![Coverage Status](https://coveralls.io/repos/komamitsu/fluency/badge.svg?branch=master&service=github)](https://coveralls.io/github/komamitsu/fluency?branch=master)
 
 High throughput data ingestion logger to Fluentd and Fluent Bit (and AWS S3 and Treasure Data.)


### PR DESCRIPTION
## Overview

* Updated Maven Central badge to use Shields.io and link to Search Maven, replacing the previous Herokuapp badge and Maven Central link.