### PR TITLE
Add tests reproducing stale TCP connection issue (#954)

### DIFF
--- a/fluency-fluentd/src/test/java/org/komamitsu/fluency/fluentd/FluencyTestWithMockServer.java
+++ b/fluency-fluentd/src/test/java/org/komamitsu/fluency/fluentd/FluencyTestWithMockServer.java
@@ -333,6 +333,7 @@ class FluencyTestWithMockServer {
   void testAckModeGuaranteesDeliveryAfterServerDropsConnections() throws Exception {
     Set<Integer> receivedIds = ConcurrentHashMap.newKeySet();
     List<Socket> acceptedSockets = new CopyOnWriteArrayList<>();
+    Value idKey = ValueFactory.newString("id");
 
     AbstractFluentdServer server =
         new AbstractFluentdServer(false) {
@@ -346,7 +347,7 @@ class FluencyTestWithMockServer {
 
               @Override
               public void onReceive(String tag, long timestampMillis, MapValue data) {
-                Value idValue = data.toMap().get(ValueFactory.newString("id"));
+                Value idValue = data.toMap().get(idKey);
                 if (idValue != null) {
                   receivedIds.add(idValue.asIntegerValue().asInt());
                 }
@@ -368,12 +369,12 @@ class FluencyTestWithMockServer {
 
       try (Fluency fluency = builder.build(server.getLocalPort())) {
         AtomicInteger recordId = new AtomicInteger(0);
-        Map<String, Object> data = new HashMap<>();
-        data.put("key", "value");
 
         for (int i = 0; i < recordsBeforeDrop; i++) {
-          data.put("id", recordId.getAndIncrement());
-          fluency.emit("tag", data);
+          Map<String, Object> record = new HashMap<>();
+          record.put("key", "value");
+          record.put("id", recordId.getAndIncrement());
+          fluency.emit("tag", record);
         }
         assertTrue(
             fluency.waitUntilAllBufferFlushed(10),
@@ -392,8 +393,10 @@ class FluencyTestWithMockServer {
         }
 
         for (int i = 0; i < recordsAfterDrop; i++) {
-          data.put("id", recordId.getAndIncrement());
-          fluency.emit("tag", data);
+          Map<String, Object> record = new HashMap<>();
+          record.put("key", "value");
+          record.put("id", recordId.getAndIncrement());
+          fluency.emit("tag", record);
         }
         assertTrue(fluency.waitUntilAllBufferFlushed(30), "Buffer should flush after reconnection");
       }

--- a/fluency-fluentd/src/test/java/org/komamitsu/fluency/fluentd/FluencyTestWithMockServer.java
+++ b/fluency-fluentd/src/test/java/org/komamitsu/fluency/fluentd/FluencyTestWithMockServer.java
@@ -386,8 +386,8 @@ class FluencyTestWithMockServer {
             "Buffer should flush before dropping connections");
 
         assertThat(acceptedSockets)
-            .as("At least one connection must have been established")
-            .isNotEmpty();
+            .as("Exactly one connection must have been established before the drop")
+            .hasSize(1);
         LOG.info("Dropping {} connections to simulate Fluentd restart", acceptedSockets.size());
         for (Socket socket : acceptedSockets) {
           try {

--- a/fluency-fluentd/src/test/java/org/komamitsu/fluency/fluentd/FluencyTestWithMockServer.java
+++ b/fluency-fluentd/src/test/java/org/komamitsu/fluency/fluentd/FluencyTestWithMockServer.java
@@ -347,7 +347,7 @@ class FluencyTestWithMockServer {
 
               @Override
               public void onReceive(String tag, long timestampMillis, MapValue data) {
-                Value idValue = data.toMap().get(idKey);
+                Value idValue = data.map().get(idKey);
                 if (idValue != null) {
                   receivedIds.add(idValue.asIntegerValue().asInt());
                 }

--- a/fluency-fluentd/src/test/java/org/komamitsu/fluency/fluentd/FluencyTestWithMockServer.java
+++ b/fluency-fluentd/src/test/java/org/komamitsu/fluency/fluentd/FluencyTestWithMockServer.java
@@ -33,12 +33,15 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Stream;
@@ -59,6 +62,7 @@ import org.komamitsu.fluency.flusher.Flusher;
 import org.msgpack.jackson.dataformat.MessagePackFactory;
 import org.msgpack.value.MapValue;
 import org.msgpack.value.Value;
+import org.msgpack.value.ValueFactory;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -327,7 +331,7 @@ class FluencyTestWithMockServer {
    */
   @Test
   void testAckModeGuaranteesDeliveryAfterServerDropsConnections() throws Exception {
-    AtomicLong receivedRecords = new AtomicLong(0);
+    Set<Integer> receivedIds = ConcurrentHashMap.newKeySet();
     List<Socket> acceptedSockets = new CopyOnWriteArrayList<>();
 
     AbstractFluentdServer server =
@@ -342,7 +346,10 @@ class FluencyTestWithMockServer {
 
               @Override
               public void onReceive(String tag, long timestampMillis, MapValue data) {
-                receivedRecords.incrementAndGet();
+                Value idValue = data.toMap().get(ValueFactory.newString("id"));
+                if (idValue != null) {
+                  receivedIds.add(idValue.asIntegerValue().asInt());
+                }
               }
 
               @Override
@@ -360,10 +367,12 @@ class FluencyTestWithMockServer {
       builder.setFlushAttemptIntervalMillis(200);
 
       try (Fluency fluency = builder.build(server.getLocalPort())) {
+        AtomicInteger recordId = new AtomicInteger(0);
         Map<String, Object> data = new HashMap<>();
         data.put("key", "value");
 
         for (int i = 0; i < recordsBeforeDrop; i++) {
+          data.put("id", recordId.getAndIncrement());
           fluency.emit("tag", data);
         }
         assertTrue(
@@ -383,6 +392,7 @@ class FluencyTestWithMockServer {
         }
 
         for (int i = 0; i < recordsAfterDrop; i++) {
+          data.put("id", recordId.getAndIncrement());
           fluency.emit("tag", data);
         }
         assertTrue(fluency.waitUntilAllBufferFlushed(30), "Buffer should flush after reconnection");
@@ -391,9 +401,11 @@ class FluencyTestWithMockServer {
       server.stop();
     }
 
-    assertThat(receivedRecords.get())
-        .as("ACK mode must deliver all records despite connection drops")
-        .isEqualTo((long) recordsBeforeDrop + recordsAfterDrop);
+    assertThat(receivedIds)
+        .as(
+            "ACK mode must deliver all %d distinct records despite connection drops",
+            recordsBeforeDrop + recordsAfterDrop)
+        .hasSize(recordsBeforeDrop + recordsAfterDrop);
   }
 
   private void testFluencyBase(final FluencyFactory fluencyFactory, final Options options)

--- a/fluency-fluentd/src/test/java/org/komamitsu/fluency/fluentd/FluencyTestWithMockServer.java
+++ b/fluency-fluentd/src/test/java/org/komamitsu/fluency/fluentd/FluencyTestWithMockServer.java
@@ -349,7 +349,10 @@ class FluencyTestWithMockServer {
               public void onReceive(String tag, long timestampMillis, MapValue data) {
                 Value idValue = data.map().get(idKey);
                 if (idValue != null) {
-                  receivedIds.add(idValue.asIntegerValue().asInt());
+                  int id = idValue.asIntegerValue().asInt();
+                  if (!receivedIds.add(id)) {
+                    throw new AssertionError("Duplicate record received: id=" + id);
+                  }
                 }
               }
 

--- a/fluency-fluentd/src/test/java/org/komamitsu/fluency/fluentd/FluencyTestWithMockServer.java
+++ b/fluency-fluentd/src/test/java/org/komamitsu/fluency/fluentd/FluencyTestWithMockServer.java
@@ -333,6 +333,7 @@ class FluencyTestWithMockServer {
   void testAckModeGuaranteesDeliveryAfterServerDropsConnections() throws Exception {
     Set<Integer> receivedIds = ConcurrentHashMap.newKeySet();
     List<Socket> acceptedSockets = new CopyOnWriteArrayList<>();
+    AtomicReference<AssertionError> backgroundError = new AtomicReference<>();
     Value idKey = ValueFactory.newString("id");
 
     AbstractFluentdServer server =
@@ -351,7 +352,8 @@ class FluencyTestWithMockServer {
                 if (idValue != null) {
                   int id = idValue.asIntegerValue().asInt();
                   if (!receivedIds.add(id)) {
-                    throw new AssertionError("Duplicate record received: id=" + id);
+                    backgroundError.compareAndSet(
+                        null, new AssertionError("Duplicate record received: id=" + id));
                   }
                 }
               }
@@ -402,6 +404,10 @@ class FluencyTestWithMockServer {
           fluency.emit("tag", record);
         }
         assertTrue(fluency.waitUntilAllBufferFlushed(30), "Buffer should flush after reconnection");
+      }
+      AssertionError error = backgroundError.get();
+      if (error != null) {
+        throw error;
       }
       assertThat(receivedIds)
           .as(

--- a/fluency-fluentd/src/test/java/org/komamitsu/fluency/fluentd/FluencyTestWithMockServer.java
+++ b/fluency-fluentd/src/test/java/org/komamitsu/fluency/fluentd/FluencyTestWithMockServer.java
@@ -361,8 +361,8 @@ class FluencyTestWithMockServer {
     int recordsBeforeDrop = 200;
     int recordsAfterDrop = 200;
 
-    server.start();
     try {
+      server.start();
       FluencyBuilderForFluentd builder = new FluencyBuilderForFluentd();
       builder.setAckResponseMode(true);
       builder.setFlushAttemptIntervalMillis(200);

--- a/fluency-fluentd/src/test/java/org/komamitsu/fluency/fluentd/FluencyTestWithMockServer.java
+++ b/fluency-fluentd/src/test/java/org/komamitsu/fluency/fluentd/FluencyTestWithMockServer.java
@@ -350,41 +350,43 @@ class FluencyTestWithMockServer {
             };
           }
         };
-    server.start();
-
     int recordsBeforeDrop = 200;
     int recordsAfterDrop = 200;
 
-    FluencyBuilderForFluentd builder = new FluencyBuilderForFluentd();
-    builder.setAckResponseMode(true);
-    builder.setFlushAttemptIntervalMillis(200);
+    server.start();
+    try {
+      FluencyBuilderForFluentd builder = new FluencyBuilderForFluentd();
+      builder.setAckResponseMode(true);
+      builder.setFlushAttemptIntervalMillis(200);
 
-    try (Fluency fluency = builder.build(server.getLocalPort())) {
-      Map<String, Object> data = new HashMap<>();
-      data.put("key", "value");
+      try (Fluency fluency = builder.build(server.getLocalPort())) {
+        Map<String, Object> data = new HashMap<>();
+        data.put("key", "value");
 
-      for (int i = 0; i < recordsBeforeDrop; i++) {
-        fluency.emit("tag", data);
-      }
-      assertTrue(
-          fluency.waitUntilAllBufferFlushed(10), "Buffer should flush before dropping connections");
-
-      assertThat(acceptedSockets)
-          .as("At least one connection must have been established")
-          .isNotEmpty();
-      LOG.info("Dropping {} connections to simulate Fluentd restart", acceptedSockets.size());
-      for (Socket socket : acceptedSockets) {
-        try {
-          socket.close();
-        } catch (IOException e) {
-          LOG.warn("Failed to close socket", e);
+        for (int i = 0; i < recordsBeforeDrop; i++) {
+          fluency.emit("tag", data);
         }
-      }
+        assertTrue(
+            fluency.waitUntilAllBufferFlushed(10),
+            "Buffer should flush before dropping connections");
 
-      for (int i = 0; i < recordsAfterDrop; i++) {
-        fluency.emit("tag", data);
+        assertThat(acceptedSockets)
+            .as("At least one connection must have been established")
+            .isNotEmpty();
+        LOG.info("Dropping {} connections to simulate Fluentd restart", acceptedSockets.size());
+        for (Socket socket : acceptedSockets) {
+          try {
+            socket.close();
+          } catch (IOException e) {
+            LOG.warn("Failed to close socket", e);
+          }
+        }
+
+        for (int i = 0; i < recordsAfterDrop; i++) {
+          fluency.emit("tag", data);
+        }
+        assertTrue(fluency.waitUntilAllBufferFlushed(30), "Buffer should flush after reconnection");
       }
-      assertTrue(fluency.waitUntilAllBufferFlushed(30), "Buffer should flush after reconnection");
     } finally {
       server.stop();
     }

--- a/fluency-fluentd/src/test/java/org/komamitsu/fluency/fluentd/FluencyTestWithMockServer.java
+++ b/fluency-fluentd/src/test/java/org/komamitsu/fluency/fluentd/FluencyTestWithMockServer.java
@@ -366,7 +366,8 @@ class FluencyTestWithMockServer {
       for (int i = 0; i < recordsBeforeDrop; i++) {
         fluency.emit("tag", data);
       }
-      fluency.waitUntilAllBufferFlushed(10);
+      assertTrue(
+          fluency.waitUntilAllBufferFlushed(10), "Buffer should flush before dropping connections");
 
       LOG.info("Dropping {} connections to simulate Fluentd restart", acceptedSockets.size());
       for (Socket socket : acceptedSockets) {
@@ -380,7 +381,7 @@ class FluencyTestWithMockServer {
       for (int i = 0; i < recordsAfterDrop; i++) {
         fluency.emit("tag", data);
       }
-      fluency.waitUntilAllBufferFlushed(30);
+      assertTrue(fluency.waitUntilAllBufferFlushed(30), "Buffer should flush after reconnection");
     } finally {
       server.stop();
     }

--- a/fluency-fluentd/src/test/java/org/komamitsu/fluency/fluentd/FluencyTestWithMockServer.java
+++ b/fluency-fluentd/src/test/java/org/komamitsu/fluency/fluentd/FluencyTestWithMockServer.java
@@ -400,15 +400,14 @@ class FluencyTestWithMockServer {
         }
         assertTrue(fluency.waitUntilAllBufferFlushed(30), "Buffer should flush after reconnection");
       }
+      assertThat(receivedIds)
+          .as(
+              "ACK mode must deliver all %d distinct records despite connection drops",
+              recordsBeforeDrop + recordsAfterDrop)
+          .hasSize(recordsBeforeDrop + recordsAfterDrop);
     } finally {
       server.stop();
     }
-
-    assertThat(receivedIds)
-        .as(
-            "ACK mode must deliver all %d distinct records despite connection drops",
-            recordsBeforeDrop + recordsAfterDrop)
-        .hasSize(recordsBeforeDrop + recordsAfterDrop);
   }
 
   private void testFluencyBase(final FluencyFactory fluencyFactory, final Options options)

--- a/fluency-fluentd/src/test/java/org/komamitsu/fluency/fluentd/FluencyTestWithMockServer.java
+++ b/fluency-fluentd/src/test/java/org/komamitsu/fluency/fluentd/FluencyTestWithMockServer.java
@@ -369,6 +369,9 @@ class FluencyTestWithMockServer {
       assertTrue(
           fluency.waitUntilAllBufferFlushed(10), "Buffer should flush before dropping connections");
 
+      assertThat(acceptedSockets)
+          .as("At least one connection must have been established")
+          .isNotEmpty();
       LOG.info("Dropping {} connections to simulate Fluentd restart", acceptedSockets.size());
       for (Socket socket : acceptedSockets) {
         try {

--- a/fluency-fluentd/src/test/java/org/komamitsu/fluency/fluentd/FluencyTestWithMockServer.java
+++ b/fluency-fluentd/src/test/java/org/komamitsu/fluency/fluentd/FluencyTestWithMockServer.java
@@ -33,6 +33,7 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Random;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -41,6 +42,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.MethodSource;
 import org.komamitsu.fluency.EventTime;
@@ -314,6 +316,78 @@ class FluencyTestWithMockServer {
           return new Fluency(buffer, flusher);
         },
         options);
+  }
+
+  /**
+   * Reproducer for https://github.com/komamitsu/fluency/issues/954
+   *
+   * <p>ACK mode detects stale connections via the ACK read path: after Fluentd drops all TCP
+   * connections, {@code recvResponse()} gets -1 from {@code read()}, which triggers {@code
+   * closeSocket()} and re-queues the in-flight chunk. All records are delivered after reconnection.
+   */
+  @Test
+  void testAckModeGuaranteesDeliveryAfterServerDropsConnections() throws Exception {
+    AtomicLong receivedRecords = new AtomicLong(0);
+    List<Socket> acceptedSockets = new CopyOnWriteArrayList<>();
+
+    AbstractFluentdServer server =
+        new AbstractFluentdServer(false) {
+          @Override
+          protected EventHandler getFluentdEventHandler() {
+            return new EventHandler() {
+              @Override
+              public void onConnect(Socket socket) {
+                acceptedSockets.add(socket);
+              }
+
+              @Override
+              public void onReceive(String tag, long timestampMillis, MapValue data) {
+                receivedRecords.incrementAndGet();
+              }
+
+              @Override
+              public void onClose(Socket socket) {}
+            };
+          }
+        };
+    server.start();
+
+    int recordsBeforeDrop = 200;
+    int recordsAfterDrop = 200;
+
+    FluencyBuilderForFluentd builder = new FluencyBuilderForFluentd();
+    builder.setAckResponseMode(true);
+    builder.setFlushAttemptIntervalMillis(200);
+
+    try (Fluency fluency = builder.build(server.getLocalPort())) {
+      Map<String, Object> data = new HashMap<>();
+      data.put("key", "value");
+
+      for (int i = 0; i < recordsBeforeDrop; i++) {
+        fluency.emit("tag", data);
+      }
+      fluency.waitUntilAllBufferFlushed(10);
+
+      LOG.info("Dropping {} connections to simulate Fluentd restart", acceptedSockets.size());
+      for (Socket socket : acceptedSockets) {
+        try {
+          socket.close();
+        } catch (IOException e) {
+          LOG.warn("Failed to close socket", e);
+        }
+      }
+
+      for (int i = 0; i < recordsAfterDrop; i++) {
+        fluency.emit("tag", data);
+      }
+      fluency.waitUntilAllBufferFlushed(30);
+    } finally {
+      server.stop();
+    }
+
+    assertThat(receivedRecords.get())
+        .as("ACK mode must deliver all records despite connection drops")
+        .isEqualTo((long) recordsBeforeDrop + recordsAfterDrop);
   }
 
   private void testFluencyBase(final FluencyFactory fluencyFactory, final Options options)

--- a/fluency-fluentd/src/test/java/org/komamitsu/fluency/fluentd/ingester/sender/TCPSenderTest.java
+++ b/fluency-fluentd/src/test/java/org/komamitsu/fluency/fluentd/ingester/sender/TCPSenderTest.java
@@ -372,56 +372,57 @@ class TCPSenderTest {
           }
         };
     server.start();
+    try {
+      TCPSender.Config config = new TCPSender.Config();
+      config.setPort(server.getLocalPort());
 
-    TCPSender.Config config = new TCPSender.Config();
-    config.setPort(server.getLocalPort());
+      try (TCPSender sender = new TCPSender(config)) {
+        byte[] data = "hello".getBytes(StandardCharsets.UTF_8);
 
-    try (TCPSender sender = new TCPSender(config)) {
-      byte[] data = "hello".getBytes(StandardCharsets.UTF_8);
+        // Establish the connection by sending initial data
+        sender.send(ByteBuffer.wrap(data));
+        assertTrue(firstDataReceivedLatch.await(5, TimeUnit.SECONDS));
 
-      // Establish the connection by sending initial data
-      sender.send(ByteBuffer.wrap(data));
-      assertTrue(firstDataReceivedLatch.await(5, TimeUnit.SECONDS));
-
-      Socket socket = firstAcceptedSocket.get();
-      assertThat(socket).isNotNull();
-      if (abruptClose) {
-        // RST path: SO_LINGER with timeout=0 makes close() send RST instead of FIN
-        socket.setSoLinger(true, 0);
-      }
-      socket.close();
-
-      // Keep sending until the server observes the reconnect (second onConnect).
-      // - RST path: the first send fails ("Connection reset"), the next send reconnects.
-      // - FIN path: sends may silently "succeed" (TCP half-close) before the RST triggers
-      //   closeSocket(); after that a send fails ("Broken pipe") and the next reconnects.
-      for (int attempt = 0; attempt < 20 && reconnectedLatch.getCount() > 0; attempt++) {
-        try {
-          sender.send(ByteBuffer.wrap(data));
-          LOG.debug("Send succeeded on attempt {}", attempt);
-        } catch (IOException e) {
-          LOG.debug("Attempt {} failed (expected on stale socket): {}", attempt, e.getMessage());
+        Socket socket = firstAcceptedSocket.get();
+        assertThat(socket).isNotNull();
+        if (abruptClose) {
+          // RST path: SO_LINGER with timeout=0 makes close() send RST instead of FIN
+          socket.setSoLinger(true, 0);
         }
-        TimeUnit.MILLISECONDS.sleep(100);
-      }
+        socket.close();
 
-      assertTrue(
-          reconnectedLatch.await(10, TimeUnit.SECONDS),
-          "TCPSender should reconnect after the server closed the connection");
-
-      // Verify stable operation on the new connection
-      int consecutiveSuccesses = 0;
-      for (int attempt = 0; attempt < 10 && consecutiveSuccesses < 3; attempt++) {
-        try {
-          sender.send(ByteBuffer.wrap(data));
-          consecutiveSuccesses++;
-        } catch (IOException e) {
-          consecutiveSuccesses = 0;
+        // Keep sending until the server observes the reconnect (second onConnect).
+        // - RST path: the first send fails ("Connection reset"), the next send reconnects.
+        // - FIN path: sends may silently "succeed" (TCP half-close) before the RST triggers
+        //   closeSocket(); after that a send fails ("Broken pipe") and the next reconnects.
+        for (int attempt = 0; attempt < 20 && reconnectedLatch.getCount() > 0; attempt++) {
+          try {
+            sender.send(ByteBuffer.wrap(data));
+            LOG.debug("Send succeeded on attempt {}", attempt);
+          } catch (IOException e) {
+            LOG.debug("Attempt {} failed (expected on stale socket): {}", attempt, e.getMessage());
+          }
+          TimeUnit.MILLISECONDS.sleep(100);
         }
+
+        assertTrue(
+            reconnectedLatch.await(10, TimeUnit.SECONDS),
+            "TCPSender should reconnect after the server closed the connection");
+
+        // Verify stable operation on the new connection
+        int consecutiveSuccesses = 0;
+        for (int attempt = 0; attempt < 10 && consecutiveSuccesses < 3; attempt++) {
+          try {
+            sender.send(ByteBuffer.wrap(data));
+            consecutiveSuccesses++;
+          } catch (IOException e) {
+            consecutiveSuccesses = 0;
+          }
+        }
+        assertTrue(
+            consecutiveSuccesses >= 3,
+            "TCPSender should reach stable operation on the new connection");
       }
-      assertTrue(
-          consecutiveSuccesses >= 3,
-          "TCPSender should reach stable operation on the new connection");
     } finally {
       server.stop();
     }

--- a/fluency-fluentd/src/test/java/org/komamitsu/fluency/fluentd/ingester/sender/TCPSenderTest.java
+++ b/fluency-fluentd/src/test/java/org/komamitsu/fluency/fluentd/ingester/sender/TCPSenderTest.java
@@ -395,19 +395,22 @@ class TCPSenderTest {
         // - RST path: the first send fails ("Connection reset"), the next send reconnects.
         // - FIN path: sends may silently "succeed" (TCP half-close) before the RST triggers
         //   closeSocket(); after that a send fails ("Broken pipe") and the next reconnects.
-        for (int attempt = 0; attempt < 20 && reconnectedLatch.getCount() > 0; attempt++) {
+        // Sends are interleaved with latch checks so a reconnect is always triggered by an
+        // actual send(), even on slow CI machines where the OS takes longer to deliver FIN/RST.
+        boolean reconnected = false;
+        long deadline = System.currentTimeMillis() + 30_000;
+        while (!reconnected && System.currentTimeMillis() < deadline) {
           try {
             sender.send(ByteBuffer.wrap(data));
-            LOG.debug("Send succeeded on attempt {}", attempt);
+            LOG.debug("Send succeeded");
           } catch (IOException e) {
-            LOG.debug("Attempt {} failed (expected on stale socket): {}", attempt, e.getMessage());
+            LOG.debug("Send failed (expected on stale socket): {}", e.getMessage());
           }
-          TimeUnit.MILLISECONDS.sleep(100);
+          reconnected = reconnectedLatch.await(100, TimeUnit.MILLISECONDS);
         }
 
         assertTrue(
-            reconnectedLatch.await(10, TimeUnit.SECONDS),
-            "TCPSender should reconnect after the server closed the connection");
+            reconnected, "TCPSender should reconnect after the server closed the connection");
 
         // Verify stable operation on the new connection
         int consecutiveSuccesses = 0;

--- a/fluency-fluentd/src/test/java/org/komamitsu/fluency/fluentd/ingester/sender/TCPSenderTest.java
+++ b/fluency-fluentd/src/test/java/org/komamitsu/fluency/fluentd/ingester/sender/TCPSenderTest.java
@@ -323,7 +323,9 @@ class TCPSenderTest {
    * reconnects successfully.
    *
    * <p>The correct fix for silent data loss is ACK mode (setAckResponseMode(true)), which was
-   * designed for at-least-once delivery. See FluencyReconnectTest for the full-stack demonstration.
+   * designed for at-least-once delivery. See {@code
+   * FluencyTestWithMockServer#testAckModeGuaranteesDeliveryAfterServerDropsConnections} for the
+   * full-stack demonstration.
    */
   @Test
   void testReconnectAfterServerClosesConnectionWithRST() throws Exception {
@@ -368,45 +370,53 @@ class TCPSenderTest {
 
     TCPSender.Config config = new TCPSender.Config();
     config.setPort(server.getLocalPort());
-    TCPSender sender = new TCPSender(config);
 
-    byte[] data = "hello".getBytes(StandardCharsets.UTF_8);
+    try (TCPSender sender = new TCPSender(config)) {
+      byte[] data = "hello".getBytes(StandardCharsets.UTF_8);
 
-    // Establish the connection by sending initial data
-    sender.send(ByteBuffer.wrap(data));
-    assertTrue(firstDataReceivedLatch.await(5, TimeUnit.SECONDS));
+      // Establish the connection by sending initial data
+      sender.send(ByteBuffer.wrap(data));
+      assertTrue(firstDataReceivedLatch.await(5, TimeUnit.SECONDS));
 
-    if (abruptClose) {
-      // RST path: SO_LINGER with timeout=0 makes close() send RST instead of FIN
-      firstAcceptedSocket.get().setSoLinger(true, 0);
-    }
-    firstAcceptedSocket.get().close();
-
-    // Allow the FIN/RST to propagate to the client
-    TimeUnit.MILLISECONDS.sleep(200);
-
-    // Keep sending until 3 consecutive successes confirm a stable reconnected state.
-    // - RST path: attempt 0 fails ("Connection reset"), attempt 1 reconnects and succeeds.
-    // - FIN path: attempt 0 silently "succeeds" (data lost — TCP two-write rule), attempt 1
-    //   fails ("Broken pipe" once RST arrives), attempt 2 reconnects and succeeds stably.
-    int consecutiveSuccesses = 0;
-    for (int attempt = 0; attempt < 10 && consecutiveSuccesses < 3; attempt++) {
-      try {
-        sender.send(ByteBuffer.wrap(data));
-        LOG.debug("Send succeeded on attempt {}", attempt);
-        consecutiveSuccesses++;
-      } catch (IOException e) {
-        LOG.debug("Attempt {} failed (expected on stale socket): {}", attempt, e.getMessage());
-        consecutiveSuccesses = 0;
+      if (abruptClose) {
+        // RST path: SO_LINGER with timeout=0 makes close() send RST instead of FIN
+        firstAcceptedSocket.get().setSoLinger(true, 0);
       }
+      firstAcceptedSocket.get().close();
+
+      // Allow the FIN/RST to propagate to the client
+      TimeUnit.MILLISECONDS.sleep(200);
+
+      // Keep sending until a reconnect is observed (connectCount > 1) and 3 consecutive successes
+      // confirm stable operation on the new connection.
+      // - RST path: attempt 0 fails ("Connection reset"), attempt 1 reconnects and succeeds.
+      // - FIN path: attempt 0 silently "succeeds" (data lost — TCP two-write rule), attempt 1
+      //   fails ("Broken pipe" once RST arrives), attempt 2 reconnects and succeeds stably.
+      int consecutiveSuccesses = 0;
+      for (int attempt = 0; attempt < 10 && consecutiveSuccesses < 3; attempt++) {
+        try {
+          sender.send(ByteBuffer.wrap(data));
+          LOG.debug("Send succeeded on attempt {}", attempt);
+          if (connectCount.get() > 1) {
+            consecutiveSuccesses++;
+          } else {
+            consecutiveSuccesses = 0;
+          }
+        } catch (IOException e) {
+          LOG.debug("Attempt {} failed (expected on stale socket): {}", attempt, e.getMessage());
+          consecutiveSuccesses = 0;
+        }
+      }
+
+      assertTrue(
+          connectCount.get() > 1,
+          "TCPSender should have reconnected after the server closed the connection");
+      assertTrue(
+          consecutiveSuccesses >= 3,
+          "TCPSender should reach stable operation on the new connection");
+    } finally {
+      server.stop();
     }
-
-    assertTrue(
-        consecutiveSuccesses >= 3,
-        "TCPSender should reconnect and reach stable operation after the server closed the connection");
-
-    sender.close();
-    server.stop();
   }
 
   interface TCPSenderCreater {

--- a/fluency-fluentd/src/test/java/org/komamitsu/fluency/fluentd/ingester/sender/TCPSenderTest.java
+++ b/fluency-fluentd/src/test/java/org/komamitsu/fluency/fluentd/ingester/sender/TCPSenderTest.java
@@ -398,7 +398,7 @@ class TCPSenderTest {
         // Sends are interleaved with latch checks so a reconnect is always triggered by an
         // actual send(), even on slow CI machines where the OS takes longer to deliver FIN/RST.
         boolean reconnected = false;
-        long deadline = System.nanoTime() + 30_000_000_000L;
+        long deadline = System.nanoTime() + TimeUnit.SECONDS.toNanos(30);
         while (!reconnected && System.nanoTime() < deadline) {
           try {
             sender.send(ByteBuffer.wrap(data));

--- a/fluency-fluentd/src/test/java/org/komamitsu/fluency/fluentd/ingester/sender/TCPSenderTest.java
+++ b/fluency-fluentd/src/test/java/org/komamitsu/fluency/fluentd/ingester/sender/TCPSenderTest.java
@@ -419,6 +419,7 @@ class TCPSenderTest {
             sender.send(ByteBuffer.wrap(data));
             consecutiveSuccesses++;
           } catch (IOException e) {
+            LOG.debug("Send failed in stability check (attempt {}): {}", attempt, e.getMessage());
             consecutiveSuccesses = 0;
           }
         }

--- a/fluency-fluentd/src/test/java/org/komamitsu/fluency/fluentd/ingester/sender/TCPSenderTest.java
+++ b/fluency-fluentd/src/test/java/org/komamitsu/fluency/fluentd/ingester/sender/TCPSenderTest.java
@@ -339,7 +339,7 @@ class TCPSenderTest {
 
   private void doTestReconnectAfterServerClosesConnection(boolean abruptClose) throws Exception {
     CountDownLatch firstDataReceivedLatch = new CountDownLatch(1);
-    AtomicInteger connectCount = new AtomicInteger(0);
+    CountDownLatch reconnectedLatch = new CountDownLatch(1);
     AtomicReference<Socket> firstAcceptedSocket = new AtomicReference<>();
 
     MockTCPServer server =
@@ -347,10 +347,15 @@ class TCPSenderTest {
           @Override
           protected EventHandler getEventHandler() {
             return new EventHandler() {
+              private final AtomicInteger connectCount = new AtomicInteger(0);
+
               @Override
               public void onConnect(Socket socket) {
-                if (connectCount.incrementAndGet() == 1) {
+                int count = connectCount.incrementAndGet();
+                if (count == 1) {
                   firstAcceptedSocket.set(socket);
+                } else if (count == 2) {
+                  reconnectedLatch.countDown();
                 }
               }
 
@@ -378,39 +383,42 @@ class TCPSenderTest {
       sender.send(ByteBuffer.wrap(data));
       assertTrue(firstDataReceivedLatch.await(5, TimeUnit.SECONDS));
 
+      Socket socket = firstAcceptedSocket.get();
+      assertThat(socket).isNotNull();
       if (abruptClose) {
         // RST path: SO_LINGER with timeout=0 makes close() send RST instead of FIN
-        firstAcceptedSocket.get().setSoLinger(true, 0);
+        socket.setSoLinger(true, 0);
       }
-      firstAcceptedSocket.get().close();
+      socket.close();
 
-      // Allow the FIN/RST to propagate to the client
-      TimeUnit.MILLISECONDS.sleep(200);
+      // Keep sending until the server observes the reconnect (second onConnect).
+      // - RST path: the first send fails ("Connection reset"), the next send reconnects.
+      // - FIN path: sends may silently "succeed" (TCP half-close) before the RST triggers
+      //   closeSocket(); after that a send fails ("Broken pipe") and the next reconnects.
+      for (int attempt = 0; attempt < 20 && reconnectedLatch.getCount() > 0; attempt++) {
+        try {
+          sender.send(ByteBuffer.wrap(data));
+          LOG.debug("Send succeeded on attempt {}", attempt);
+        } catch (IOException e) {
+          LOG.debug("Attempt {} failed (expected on stale socket): {}", attempt, e.getMessage());
+        }
+        TimeUnit.MILLISECONDS.sleep(100);
+      }
 
-      // Keep sending until a reconnect is observed (connectCount > 1) and 3 consecutive successes
-      // confirm stable operation on the new connection.
-      // - RST path: attempt 0 fails ("Connection reset"), attempt 1 reconnects and succeeds.
-      // - FIN path: attempt 0 silently "succeeds" (data lost — TCP two-write rule), attempt 1
-      //   fails ("Broken pipe" once RST arrives), attempt 2 reconnects and succeeds stably.
+      assertTrue(
+          reconnectedLatch.await(10, TimeUnit.SECONDS),
+          "TCPSender should reconnect after the server closed the connection");
+
+      // Verify stable operation on the new connection
       int consecutiveSuccesses = 0;
       for (int attempt = 0; attempt < 10 && consecutiveSuccesses < 3; attempt++) {
         try {
           sender.send(ByteBuffer.wrap(data));
-          LOG.debug("Send succeeded on attempt {}", attempt);
-          if (connectCount.get() > 1) {
-            consecutiveSuccesses++;
-          } else {
-            consecutiveSuccesses = 0;
-          }
+          consecutiveSuccesses++;
         } catch (IOException e) {
-          LOG.debug("Attempt {} failed (expected on stale socket): {}", attempt, e.getMessage());
           consecutiveSuccesses = 0;
         }
       }
-
-      assertTrue(
-          connectCount.get() > 1,
-          "TCPSender should have reconnected after the server closed the connection");
       assertTrue(
           consecutiveSuccesses >= 3,
           "TCPSender should reach stable operation on the new connection");

--- a/fluency-fluentd/src/test/java/org/komamitsu/fluency/fluentd/ingester/sender/TCPSenderTest.java
+++ b/fluency-fluentd/src/test/java/org/komamitsu/fluency/fluentd/ingester/sender/TCPSenderTest.java
@@ -318,9 +318,9 @@ class TCPSenderTest {
    *
    * <p>Scenario B (graceful / FIN): The server closes normally, sending FIN. Due to TCP half-close
    * the first write may silently "succeed" — the OS places data in the send buffer before the RST
-   * triggered by the peer's close arrives. That data is silently lost at the TCPSender level. The
-   * second write fails ("Broken pipe"), closeSocket() nulls the channel, and the third send
-   * reconnects successfully.
+   * triggered by the peer's close arrives. That data may be silently lost at the TCPSender level
+   * (this test only verifies reconnection, not data loss). The second write fails ("Broken pipe"),
+   * closeSocket() nulls the channel, and the third send reconnects successfully.
    *
    * <p>The correct fix for silent data loss is ACK mode (setAckResponseMode(true)), which was
    * designed for at-least-once delivery. See {@code

--- a/fluency-fluentd/src/test/java/org/komamitsu/fluency/fluentd/ingester/sender/TCPSenderTest.java
+++ b/fluency-fluentd/src/test/java/org/komamitsu/fluency/fluentd/ingester/sender/TCPSenderTest.java
@@ -384,7 +384,7 @@ class TCPSenderTest {
         assertTrue(firstDataReceivedLatch.await(5, TimeUnit.SECONDS));
 
         Socket socket = firstAcceptedSocket.get();
-        assertThat(socket).isNotNull();
+        assertThat(socket).as("Server should have accepted the initial connection").isNotNull();
         if (abruptClose) {
           // RST path: SO_LINGER with timeout=0 makes close() send RST instead of FIN
           socket.setSoLinger(true, 0);
@@ -398,8 +398,8 @@ class TCPSenderTest {
         // Sends are interleaved with latch checks so a reconnect is always triggered by an
         // actual send(), even on slow CI machines where the OS takes longer to deliver FIN/RST.
         boolean reconnected = false;
-        long deadline = System.currentTimeMillis() + 30_000;
-        while (!reconnected && System.currentTimeMillis() < deadline) {
+        long deadline = System.nanoTime() + 30_000_000_000L;
+        while (!reconnected && System.nanoTime() < deadline) {
           try {
             sender.send(ByteBuffer.wrap(data));
             LOG.debug("Send succeeded");
@@ -412,15 +412,20 @@ class TCPSenderTest {
         assertTrue(
             reconnected, "TCPSender should reconnect after the server closed the connection");
 
-        // Verify stable operation on the new connection
+        // Verify stable operation on the new connection.
+        // Counts failures separately so a late transient failure doesn't exhaust the attempt budget
+        // before 3 consecutive successes can be accumulated.
         int consecutiveSuccesses = 0;
-        for (int attempt = 0; attempt < 10 && consecutiveSuccesses < 3; attempt++) {
+        int failureCount = 0;
+        while (consecutiveSuccesses < 3 && failureCount <= 10) {
           try {
             sender.send(ByteBuffer.wrap(data));
             consecutiveSuccesses++;
           } catch (IOException e) {
-            LOG.debug("Send failed in stability check (attempt {}): {}", attempt, e.getMessage());
+            LOG.debug(
+                "Send failed in stability check (failure {}): {}", failureCount, e.getMessage());
             consecutiveSuccesses = 0;
+            failureCount++;
           }
         }
         assertTrue(

--- a/fluency-fluentd/src/test/java/org/komamitsu/fluency/fluentd/ingester/sender/TCPSenderTest.java
+++ b/fluency-fluentd/src/test/java/org/komamitsu/fluency/fluentd/ingester/sender/TCPSenderTest.java
@@ -316,11 +316,11 @@ class TCPSenderTest {
    * <p>Scenario A (abrupt / RST): The server closes with SO_LINGER=0, sending a TCP RST. The first
    * write on the stale channel fails immediately and the sender reconnects on the next attempt.
    *
-   * <p>Scenario B (graceful / FIN): The server closes normally, sending FIN. Due to TCP half-close
-   * the first write may silently "succeed" — the OS places data in the send buffer before the RST
-   * triggered by the peer's close arrives. That data may be silently lost at the TCPSender level
-   * (this test only verifies reconnection, not data loss). The second write fails ("Broken pipe"),
-   * closeSocket() nulls the channel, and the third send reconnects successfully.
+   * <p>Scenario B (graceful / FIN): The server closes normally, sending FIN. Due to TCP half-close,
+   * one or more writes may silently "succeed" — the OS buffers the data before the peer's RST
+   * arrives. That data may be silently lost at the TCPSender level (this test only verifies
+   * reconnection, not data loss). Eventually a write fails ("Broken pipe"), closeSocket() nulls the
+   * channel, and the next send reconnects successfully.
    *
    * <p>The correct fix for silent data loss is ACK mode (setAckResponseMode(true)), which was
    * designed for at-least-once delivery. See {@code
@@ -371,8 +371,8 @@ class TCPSenderTest {
             };
           }
         };
-    server.start();
     try {
+      server.start();
       TCPSender.Config config = new TCPSender.Config();
       config.setPort(server.getLocalPort());
 

--- a/fluency-fluentd/src/test/java/org/komamitsu/fluency/fluentd/ingester/sender/TCPSenderTest.java
+++ b/fluency-fluentd/src/test/java/org/komamitsu/fluency/fluentd/ingester/sender/TCPSenderTest.java
@@ -412,25 +412,10 @@ class TCPSenderTest {
         assertTrue(
             reconnected, "TCPSender should reconnect after the server closed the connection");
 
-        // Verify stable operation on the new connection.
-        // Counts failures separately so a late transient failure doesn't exhaust the attempt budget
-        // before 3 consecutive successes can be accumulated.
-        int consecutiveSuccesses = 0;
-        int failureCount = 0;
-        while (consecutiveSuccesses < 3 && failureCount <= 10) {
-          try {
-            sender.send(ByteBuffer.wrap(data));
-            consecutiveSuccesses++;
-          } catch (IOException e) {
-            LOG.debug(
-                "Send failed in stability check (failure {}): {}", failureCount, e.getMessage());
-            consecutiveSuccesses = 0;
-            failureCount++;
-          }
+        // Verify the new connection is stable
+        for (int i = 0; i < 3; i++) {
+          sender.send(ByteBuffer.wrap(data));
         }
-        assertTrue(
-            consecutiveSuccesses >= 3,
-            "TCPSender should reach stable operation on the new connection");
       }
     } finally {
       server.stop();

--- a/fluency-fluentd/src/test/java/org/komamitsu/fluency/fluentd/ingester/sender/TCPSenderTest.java
+++ b/fluency-fluentd/src/test/java/org/komamitsu/fluency/fluentd/ingester/sender/TCPSenderTest.java
@@ -22,6 +22,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
+import java.net.Socket;
 import java.net.SocketException;
 import java.net.SocketTimeoutException;
 import java.nio.ByteBuffer;
@@ -33,7 +34,9 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
 import org.junit.jupiter.api.Test;
 import org.komamitsu.fluency.fluentd.MockTCPServer;
@@ -305,6 +308,105 @@ class TCPSenderTest {
       config.setWaitBeforeCloseMilli(-1);
       assertThrows(IllegalArgumentException.class, () -> new TCPSender(config));
     }
+  }
+
+  /**
+   * Reproducer for https://github.com/komamitsu/fluency/issues/954
+   *
+   * <p>Scenario A (abrupt / RST): The server closes with SO_LINGER=0, sending a TCP RST. The first
+   * write on the stale channel fails immediately and the sender reconnects on the next attempt.
+   *
+   * <p>Scenario B (graceful / FIN): The server closes normally, sending FIN. Due to TCP half-close
+   * the first write may silently "succeed" — the OS places data in the send buffer before the RST
+   * triggered by the peer's close arrives. That data is silently lost at the TCPSender level. The
+   * second write fails ("Broken pipe"), closeSocket() nulls the channel, and the third send
+   * reconnects successfully.
+   *
+   * <p>The correct fix for silent data loss is ACK mode (setAckResponseMode(true)), which was
+   * designed for at-least-once delivery. See FluencyReconnectTest for the full-stack demonstration.
+   */
+  @Test
+  void testReconnectAfterServerClosesConnectionWithRST() throws Exception {
+    doTestReconnectAfterServerClosesConnection(true);
+  }
+
+  @Test
+  void testReconnectAfterServerClosesConnectionWithFIN() throws Exception {
+    doTestReconnectAfterServerClosesConnection(false);
+  }
+
+  private void doTestReconnectAfterServerClosesConnection(boolean abruptClose) throws Exception {
+    CountDownLatch firstDataReceivedLatch = new CountDownLatch(1);
+    AtomicInteger connectCount = new AtomicInteger(0);
+    AtomicReference<Socket> firstAcceptedSocket = new AtomicReference<>();
+
+    MockTCPServer server =
+        new MockTCPServer(false) {
+          @Override
+          protected EventHandler getEventHandler() {
+            return new EventHandler() {
+              @Override
+              public void onConnect(Socket socket) {
+                if (connectCount.incrementAndGet() == 1) {
+                  firstAcceptedSocket.set(socket);
+                }
+              }
+
+              @Override
+              public void onReceive(Socket socket, int len, byte[] data) {
+                if (socket == firstAcceptedSocket.get()) {
+                  firstDataReceivedLatch.countDown();
+                }
+              }
+
+              @Override
+              public void onClose(Socket socket) {}
+            };
+          }
+        };
+    server.start();
+
+    TCPSender.Config config = new TCPSender.Config();
+    config.setPort(server.getLocalPort());
+    TCPSender sender = new TCPSender(config);
+
+    byte[] data = "hello".getBytes(StandardCharsets.UTF_8);
+
+    // Establish the connection by sending initial data
+    sender.send(ByteBuffer.wrap(data));
+    assertTrue(firstDataReceivedLatch.await(5, TimeUnit.SECONDS));
+
+    if (abruptClose) {
+      // RST path: SO_LINGER with timeout=0 makes close() send RST instead of FIN
+      firstAcceptedSocket.get().setSoLinger(true, 0);
+    }
+    firstAcceptedSocket.get().close();
+
+    // Allow the FIN/RST to propagate to the client
+    TimeUnit.MILLISECONDS.sleep(200);
+
+    // Keep sending until 3 consecutive successes confirm a stable reconnected state.
+    // - RST path: attempt 0 fails ("Connection reset"), attempt 1 reconnects and succeeds.
+    // - FIN path: attempt 0 silently "succeeds" (data lost — TCP two-write rule), attempt 1
+    //   fails ("Broken pipe" once RST arrives), attempt 2 reconnects and succeeds stably.
+    int consecutiveSuccesses = 0;
+    for (int attempt = 0; attempt < 10 && consecutiveSuccesses < 3; attempt++) {
+      try {
+        sender.send(ByteBuffer.wrap(data));
+        LOG.debug("Send succeeded on attempt {}", attempt);
+        consecutiveSuccesses++;
+      } catch (IOException e) {
+        LOG.debug("Attempt {} failed (expected on stale socket): {}", attempt, e.getMessage());
+        consecutiveSuccesses = 0;
+      }
+    }
+
+    assertTrue(
+        consecutiveSuccesses >= 3,
+        "TCPSender should reconnect and reach stable operation after the server closed the connection");
+
+    sender.close();
+    server.stop();
   }
 
   interface TCPSenderCreater {


### PR DESCRIPTION
## Summary

- Adds `TCPSenderTest` cases that document RST and FIN reconnection behavior at the sender level, explaining why graceful FIN causes silent data loss (TCP two-write rule) while ACK mode avoids it
- Adds `testAckModeGuaranteesDeliveryAfterServerDropsConnections` to `FluencyTestWithMockServer` to demonstrate end-to-end that ACK mode (`setAckResponseMode(true)`) delivers all records after a simulated Fluentd restart that drops all TCP connections

Closes #954